### PR TITLE
Fix path for copying environment example file

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ bun install
 3. Set up your environment variables:
 ```bash
 # Copy the example environment file (from parent directory)
-cp ../env.example .env
+cp env.example .env
 
 # Edit .env and add your API keys
 # OPENAI_API_KEY=your-openai-api-key


### PR DESCRIPTION
After running step 1., we are in the dexter directory.

therefore `cp env.example .env` is the right command.