### PR TITLE
Use small, medium, large models across Dexter

### DIFF
--- a/src/agent/tool-executor.ts
+++ b/src/agent/tool-executor.ts
@@ -6,18 +6,13 @@ import { getToolSelectionSystemPrompt, buildToolSelectionPrompt } from './prompt
 import type { Task, ToolCallStatus, Understanding } from './state.js';
 
 // ============================================================================
-// Constants
-// ============================================================================
-
-const SMALL_MODEL = 'gpt-5-mini';
-
-// ============================================================================
 // Tool Executor Options
 // ============================================================================
 
 export interface ToolExecutorOptions {
   tools: StructuredToolInterface[];
   contextManager: ToolContextManager;
+  model: string;
 }
 
 // ============================================================================
@@ -35,21 +30,23 @@ export interface ToolExecutorCallbacks {
 
 /**
  * Handles tool selection and execution for tasks.
- * Uses a small, fast model (gpt-5-mini) for tool selection.
+ * Uses a small, fast model for tool selection.
  */
 export class ToolExecutor {
   private readonly tools: StructuredToolInterface[];
   private readonly toolMap: Map<string, StructuredToolInterface>;
   private readonly contextManager: ToolContextManager;
+  private readonly model: string;
 
   constructor(options: ToolExecutorOptions) {
     this.tools = options.tools;
     this.toolMap = new Map(options.tools.map(t => [t.name, t]));
     this.contextManager = options.contextManager;
+    this.model = options.model;
   }
 
   /**
-   * Selects tools for a task using gpt-5-mini with bound tools.
+   * Selects tools for a task using the configured model with bound tools.
    * Uses a precise, well-defined prompt optimized for small models.
    */
   async selectTools(
@@ -68,7 +65,7 @@ export class ToolExecutor {
     const systemPrompt = getToolSelectionSystemPrompt(this.formatToolDescriptions());
 
     const response = await callLlm(prompt, {
-      model: SMALL_MODEL,
+      model: this.model,
       systemPrompt,
       tools: this.tools,
     });

--- a/src/components/ModelSelector.tsx
+++ b/src/components/ModelSelector.tsx
@@ -2,10 +2,16 @@ import React, { useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { colors } from '../theme.js';
 
+export interface ModelConfig {
+  small: string;
+  medium: string;
+  large: string;
+}
+
 interface Provider {
   displayName: string;
   providerId: string;
-  modelId: string;
+  modelConfig: ModelConfig;
   description: string;
 }
 
@@ -13,30 +19,59 @@ const PROVIDERS: Provider[] = [
   {
     displayName: 'OpenAI',
     providerId: 'openai',
-    modelId: 'gpt-5.2',
+    modelConfig: {
+      small: 'gpt-5.2',
+      medium: 'gpt-5.2',
+      large: 'gpt-5.2',
+    },
     description: "GPT 5.2 - OpenAI's flagship model",
   },
   {
     displayName: 'Anthropic',
     providerId: 'anthropic',
-    modelId: 'claude-sonnet-4-5',
+    modelConfig: {
+      small: 'claude-sonnet-4-5',
+      medium: 'claude-sonnet-4-5',
+      large: 'claude-sonnet-4-5',
+    },
     description: "Sonnet 4.5 - Best for complex agents",
   },
   {
     displayName: 'Google',
     providerId: 'google',
-    modelId: 'gemini-3',
+    modelConfig: {
+      small: 'gemini-3',
+      medium: 'gemini-3',
+      large: 'gemini-3',
+    },
     description: "Gemini 3 - Google's most intelligent model",
   },
 ];
 
-export function getModelIdForProvider(providerId: string): string | undefined {
+export function getModelConfigForProvider(providerId: string): ModelConfig | undefined {
   const provider = PROVIDERS.find((p) => p.providerId === providerId);
-  return provider?.modelId;
+  return provider?.modelConfig;
+}
+
+export function getModelForProvider(
+  providerId: string,
+  size: 'small' | 'medium' | 'large'
+): string | undefined {
+  const config = getModelConfigForProvider(providerId);
+  return config?.[size];
+}
+
+export function getModelIdForProvider(providerId: string): string | undefined {
+  const config = getModelConfigForProvider(providerId);
+  return config?.large;
 }
 
 export function getProviderIdForModel(modelId: string): string | undefined {
-  const provider = PROVIDERS.find((p) => p.modelId === modelId);
+  const provider = PROVIDERS.find((p) => 
+    p.modelConfig.small === modelId || 
+    p.modelConfig.medium === modelId || 
+    p.modelConfig.large === modelId
+  );
   return provider?.providerId;
 }
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,7 +1,8 @@
 export { Intro } from './Intro.js';
 export { Input } from './Input.js';
 export { AnswerBox, UserQuery } from './AnswerBox.js';
-export { ProviderSelector, PROVIDERS, getModelIdForProvider, getProviderIdForModel } from './ModelSelector.js';
+export { ProviderSelector, PROVIDERS, getModelIdForProvider, getProviderIdForModel, getModelConfigForProvider, getModelForProvider } from './ModelSelector.js';
+export type { ModelConfig } from './ModelSelector.js';
 export { ApiKeyConfirm, ApiKeyInput } from './ApiKeyPrompt.js';
 export { QueueDisplay } from './QueueDisplay.js';
 export { StatusMessage } from './StatusMessage.js';

--- a/src/hooks/useAgentExecution.ts
+++ b/src/hooks/useAgentExecution.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef } from 'react';
 import { Agent, AgentCallbacks } from '../agent/orchestrator.js';
 import { MessageHistory } from '../utils/message-history.js';
 import { generateId } from '../cli/types.js';
+import type { ModelConfig } from '../components/ModelSelector.js';
 import type { Task, Phase, TaskStatus, ToolCallStatus, Plan } from '../agent/state.js';
 import type { AgentProgressState } from '../components/AgentProgressView.js';
 
@@ -19,7 +20,7 @@ export interface CurrentTurn {
 }
 
 interface UseAgentExecutionOptions {
-  model: string;
+  model: ModelConfig;
   messageHistory: MessageHistory;
 }
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -12,6 +12,7 @@ const PROVIDER_API_KEY_MAP: Record<string, string> = {
 };
 
 // Map model IDs to their required API key environment variable names (for backwards compatibility)
+// Note: All three sizes (small/medium/large) currently use the same model IDs, so they map to the same API keys
 const MODEL_API_KEY_MAP: Record<string, string> = {
   'gpt-5.2': 'OPENAI_API_KEY',
   'claude-sonnet-4-5': 'ANTHROPIC_API_KEY',


### PR DESCRIPTION
**Context:**

Creates scaffolding that allows Dexter to use different model sizes for different tasks (e.g. small for query understanding, large for answer generation, etc.)