### PR TITLE
feat: add OpenRouter provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Dexter takes complex financial questions and turns them into clear, step-by-step
 - OpenAI API key (get [here](https://platform.openai.com/api-keys))
 - Financial Datasets API key (get [here](https://financialdatasets.ai))
 - Tavily API key (get [here](https://tavily.com)) - optional, for web search
+- OpenRouter API key (get [here](https://openrouter.ai/keys)) - optional, unified access to multiple providers
 
 #### Installing Bun
 
@@ -117,7 +118,7 @@ Dexter uses a multi-agent architecture with specialized components:
 
 - **Runtime**: [Bun](https://bun.sh)
 - **UI Framework**: [React](https://react.dev) + [Ink](https://github.com/vadimdemedes/ink) (terminal UI)
-- **LLM Integration**: [LangChain.js](https://js.langchain.com) with multi-provider support (OpenAI, Anthropic, Google)
+- **LLM Integration**: [LangChain.js](https://js.langchain.com) with multi-provider support (OpenAI, Anthropic, Google, OpenRouter)
 - **Schema Validation**: [Zod](https://zod.dev)
 - **Language**: TypeScript
 
@@ -128,6 +129,7 @@ Type `/model` in the CLI to switch between:
 - GPT 4.1 (OpenAI)
 - Claude Sonnet 4.5 (Anthropic)
 - Gemini 3 (Google)
+- OpenRouter (unified access to GPT-5.2, Claude Opus 4.5, Gemini 3 Pro)
 
 ## How to Contribute
 

--- a/env.example
+++ b/env.example
@@ -6,6 +6,9 @@ GOOGLE_API_KEY=your-api-key
 # Ollama (Local LLM)
 OLLAMA_BASE_URL=http://127.0.0.1:11434
 
+# OpenRouter
+OPENROUTER_API_KEY=your-api-key
+
 # Stock Market API Key
 FINANCIAL_DATASETS_API_KEY=your-api-key
 

--- a/src/components/ModelSelector.tsx
+++ b/src/components/ModelSelector.tsx
@@ -27,7 +27,12 @@ const PROVIDERS: Provider[] = [
   {
     displayName: 'Ollama',
     providerId: 'ollama',
-    models: [], // Populated dynamically from local Ollama API
+    models: [],
+  },
+  {
+    displayName: 'OpenRouter',
+    providerId: 'openrouter',
+    models: ['openai/gpt-5.2', 'anthropic/claude-opus-4.5', 'google/gemini-3-pro-preview'],
   },
 ];
 
@@ -42,9 +47,11 @@ export function getDefaultModelForProvider(providerId: string): string | undefin
 }
 
 export function getProviderIdForModel(modelId: string): string | undefined {
-  // For ollama models, they're prefixed with "ollama:"
   if (modelId.startsWith('ollama:')) {
     return 'ollama';
+  }
+  if (modelId.includes('/')) {
+    return 'openrouter';
   }
   for (const provider of PROVIDERS) {
     if (provider.models.includes(modelId)) {

--- a/src/model/llm.ts
+++ b/src/model/llm.ts
@@ -40,6 +40,8 @@ function getApiKey(envVar: string, providerName: string): string {
   return apiKey;
 }
 
+const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+
 const MODEL_PROVIDERS: Record<string, ModelFactory> = {
   'claude-': (name, opts) =>
     new ChatAnthropic({
@@ -58,6 +60,27 @@ const MODEL_PROVIDERS: Record<string, ModelFactory> = {
       model: name.replace(/^ollama:/, ''),
       ...opts,
       ...(process.env.OLLAMA_BASE_URL ? { baseUrl: process.env.OLLAMA_BASE_URL } : {}),
+    }),
+  'openai/': (name, opts) =>
+    new ChatOpenAI({
+      model: name,
+      ...opts,
+      apiKey: getApiKey('OPENROUTER_API_KEY', 'OpenRouter'),
+      configuration: { baseURL: OPENROUTER_BASE_URL },
+    }),
+  'anthropic/': (name, opts) =>
+    new ChatOpenAI({
+      model: name,
+      ...opts,
+      apiKey: getApiKey('OPENROUTER_API_KEY', 'OpenRouter'),
+      configuration: { baseURL: OPENROUTER_BASE_URL },
+    }),
+  'google/': (name, opts) =>
+    new ChatOpenAI({
+      model: name,
+      ...opts,
+      apiKey: getApiKey('OPENROUTER_API_KEY', 'OpenRouter'),
+      configuration: { baseURL: OPENROUTER_BASE_URL },
     }),
 };
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -15,6 +15,7 @@ const PROVIDERS: Record<string, ProviderConfig> = {
   anthropic: { displayName: 'Anthropic', apiKeyEnvVar: 'ANTHROPIC_API_KEY' },
   google: { displayName: 'Google', apiKeyEnvVar: 'GOOGLE_API_KEY' },
   ollama: { displayName: 'Ollama' },
+  openrouter: { displayName: 'OpenRouter', apiKeyEnvVar: 'OPENROUTER_API_KEY' },
 };
 
 export function getApiKeyNameForProvider(providerId: string): string | undefined {


### PR DESCRIPTION
Adds OpenRouter as an LLM provider, enabling unified access to multiple models via a single API key.

**Changes:**
- [llm.ts](cci:7://file:///Users/rushout/Desktop/dexter/src/model/llm.ts:0:0-0:0): Add model factories for `openai/`, `anthropic/`, `google/` prefixes
- [ModelSelector.tsx](cci:7://file:///Users/rushout/Desktop/dexter/src/components/ModelSelector.tsx:0:0-0:0): Add OpenRouter with GPT-5.2, Claude Opus 4.5, Gemini 3 Pro
- [env.ts](cci:7://file:///Users/rushout/Desktop/dexter/src/utils/env.ts:0:0-0:0): Add openrouter to provider config
- [env.example](cci:7://file:///Users/rushout/Desktop/dexter/env.example:0:0-0:0) & [README.md](cci:7://file:///Users/rushout/Desktop/dexter/README.md:0:0-0:0): Document usage

Closes #26