### PR TITLE
Fix: Use user's selected model for tool selection + Add OpenRouter su…

### DIFF
--- a/src/agent/orchestrator.ts
+++ b/src/agent/orchestrator.ts
@@ -75,7 +75,7 @@ export interface AgentOptions {
  * Architecture:
  * 1. Understand: Extract intent and entities from query (once)
  * 2. Plan: Create task list with taskType and dependencies
- * 3. Execute: Run tasks with just-in-time tool selection (gpt-5-mini)
+ * 3. Execute: Run tasks with just-in-time tool selection
  * 4. Reflect: Evaluate if we have enough data or need another iteration
  * 5. Answer: Synthesize final answer from all task results
  * 
@@ -112,6 +112,7 @@ export class Agent {
 
     // Initialize executors
     const toolExecutor = new ToolExecutor({
+      model: this.model,
       tools: TOOLS,
       contextManager: this.contextManager,
     });

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -154,11 +154,11 @@ export function getPlanSystemPrompt(): string {
 }
 
 // ============================================================================
-// Tool Selection Prompt (for gpt-5-mini during execution)
+// Tool Selection Prompt
 // ============================================================================
 
 /**
- * System prompt for tool selection - kept minimal and precise for gpt-5-mini.
+ * System prompt for tool selection.
  */
 export const TOOL_SELECTION_SYSTEM_PROMPT = `Select and call tools to complete the task. Use the provided tickers and parameters.
 

--- a/src/agent/tool-executor.ts
+++ b/src/agent/tool-executor.ts
@@ -6,16 +6,11 @@ import { getToolSelectionSystemPrompt, buildToolSelectionPrompt } from './prompt
 import type { Task, ToolCallStatus, Understanding } from './state.js';
 
 // ============================================================================
-// Constants
-// ============================================================================
-
-const SMALL_MODEL = 'gpt-5-mini';
-
-// ============================================================================
 // Tool Executor Options
 // ============================================================================
 
 export interface ToolExecutorOptions {
+  model: string;
   tools: StructuredToolInterface[];
   contextManager: ToolContextManager;
 }
@@ -34,22 +29,23 @@ export interface ToolExecutorCallbacks {
 
 /**
  * Handles tool selection and execution for tasks.
- * Uses a small, fast model (gpt-5-mini) for tool selection.
+ * Uses the user's selected model for tool selection.
  */
 export class ToolExecutor {
+  private readonly model: string;
   private readonly tools: StructuredToolInterface[];
   private readonly toolMap: Map<string, StructuredToolInterface>;
   private readonly contextManager: ToolContextManager;
 
   constructor(options: ToolExecutorOptions) {
+    this.model = options.model;
     this.tools = options.tools;
     this.toolMap = new Map(options.tools.map(t => [t.name, t]));
     this.contextManager = options.contextManager;
   }
 
   /**
-   * Selects tools for a task using gpt-5-mini with bound tools.
-   * Uses a precise, well-defined prompt optimized for small models.
+   * Selects tools for a task using the user's selected model with bound tools.
    */
   async selectTools(
     task: Task,
@@ -58,7 +54,7 @@ export class ToolExecutor {
     const tickers = understanding.entities
       .filter(e => e.type === 'ticker')
       .map(e => e.value);
-    
+
     const periods = understanding.entities
       .filter(e => e.type === 'period')
       .map(e => e.value);
@@ -67,7 +63,7 @@ export class ToolExecutor {
     const systemPrompt = getToolSelectionSystemPrompt(this.formatToolDescriptions());
 
     const response = await callLlm(prompt, {
-      model: SMALL_MODEL,
+      model: this.model,
       systemPrompt,
       tools: this.tools,
     });

--- a/src/components/ModelSelector.tsx
+++ b/src/components/ModelSelector.tsx
@@ -25,6 +25,17 @@ const PROVIDERS: Provider[] = [
     models: ['gemini-3-flash-preview', 'gemini-3-pro-preview'],
   },
   {
+    displayName: 'OpenRouter',
+    providerId: 'openrouter',
+    models: [
+      'openrouter:anthropic/claude-3.5-sonnet',
+      'openrouter:openai/gpt-4o',
+      'openrouter:google/gemini-2.0-flash-exp:free',
+      'openrouter:deepseek/deepseek-r1',
+      'openrouter:meta-llama/llama-3.3-70b-instruct',
+    ],
+  },
+  {
     displayName: 'Ollama',
     providerId: 'ollama',
     models: [], // Populated dynamically from local Ollama API
@@ -45,6 +56,10 @@ export function getProviderIdForModel(modelId: string): string | undefined {
   // For ollama models, they're prefixed with "ollama:"
   if (modelId.startsWith('ollama:')) {
     return 'ollama';
+  }
+  // For openrouter models, they're prefixed with "openrouter:"
+  if (modelId.startsWith('openrouter:')) {
+    return 'openrouter';
   }
   for (const provider of PROVIDERS) {
     if (provider.models.includes(modelId)) {

--- a/src/model/llm.ts
+++ b/src/model/llm.ts
@@ -59,6 +59,15 @@ const MODEL_PROVIDERS: Record<string, ModelFactory> = {
       ...opts,
       ...(process.env.OLLAMA_BASE_URL ? { baseUrl: process.env.OLLAMA_BASE_URL } : {}),
     }),
+  'openrouter:': (name, opts) =>
+    new ChatOpenAI({
+      model: name.replace(/^openrouter:/, ''),
+      ...opts,
+      apiKey: getApiKey('OPENROUTER_API_KEY', 'OpenRouter'),
+      configuration: {
+        baseURL: 'https://openrouter.ai/api/v1',
+      },
+    }),
 };
 
 const DEFAULT_MODEL_FACTORY: ModelFactory = (name, opts) =>

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -6,8 +6,11 @@ const SETTINGS_FILE = '.dexter/settings.json';
 // Map legacy model IDs to provider IDs for migration
 const MODEL_TO_PROVIDER_MAP: Record<string, string> = {
   'gpt-5.2': 'openai',
+  'gpt-4.1': 'openai',
   'claude-sonnet-4-5': 'anthropic',
-  'gemini-3': 'google',
+  'claude-opus-4-5': 'anthropic',
+  'gemini-3-flash-preview': 'google',
+  'gemini-3-pro-preview': 'google',
 };
 
 interface Config {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -14,6 +14,7 @@ const PROVIDERS: Record<string, ProviderConfig> = {
   openai: { displayName: 'OpenAI', apiKeyEnvVar: 'OPENAI_API_KEY' },
   anthropic: { displayName: 'Anthropic', apiKeyEnvVar: 'ANTHROPIC_API_KEY' },
   google: { displayName: 'Google', apiKeyEnvVar: 'GOOGLE_API_KEY' },
+  openrouter: { displayName: 'OpenRouter', apiKeyEnvVar: 'OPENROUTER_API_KEY' },
   ollama: { displayName: 'Ollama' },
 };
 


### PR DESCRIPTION
…pport

Fixes #30: Tool selection now uses the user's selected model instead of hardcoded OpenAI gpt-5-mini.

Bug Fix:
- Remove hardcoded SMALL_MODEL constant from tool-executor.ts
- Pass model through ToolExecutorOptions interface
- Use this.model in selectTools() instead of hardcoded value

New Feature - OpenRouter Support:
- Add openrouter: prefix handler in llm.ts using OpenAI SDK
- Add OpenRouter provider to ModelSelector with popular models
- Add OPENROUTER_API_KEY to env.ts provider config

Additional:
- Fix incomplete MODEL_TO_PROVIDER_MAP in config.ts migration

Authored by CG-8663 utilising Claude Opus 4.5 and BMAD spec engineering