### PR TITLE
Add batch mode for running research on multiple tickers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Development Commands
+
+```bash
+bun start              # Run the CLI application (interactive)
+bun dev                # Watch mode for development
+bun batch <file.txt>   # Batch mode - run research on multiple tickers
+bun typecheck          # TypeScript type checking
+bun test               # Run Jest test suite
+bun test --watch       # Watch mode for tests
+```
+
+### Batch Mode
+Run research on multiple tickers with JSON output:
+```bash
+bun batch tickers.txt                                    # One ticker per line
+bun batch tickers.txt --output ./research                # Custom output dir
+bun batch tickers.txt --template "Analyze {TICKER}..."   # Custom query template
+```
+Output: `outputs/<TICKER>.json` with query, answer, tasks, and metadata.
+
+## Architecture Overview
+
+Dexter is an autonomous financial research agent built with TypeScript/Bun that uses a **5-phase orchestration loop**:
+
+```
+UNDERSTAND (once) → PLAN → EXECUTE → REFLECT → (loop back to PLAN if needed) → ANSWER
+```
+
+### Phase Details
+- **Understand**: Extract intent and entities from user query (runs once)
+- **Plan**: Create task list with `taskType` ("use_tools" or "reason") and dependencies
+- **Execute**: Run tasks in parallel respecting dependencies; tool selection happens at execution time using gpt-5-mini
+- **Reflect**: Check if sufficient data collected; if not, loop back to Plan (max 5 iterations)
+- **Answer**: Stream final response using accumulated context
+
+### Key Directories
+
+```
+src/
+├── agent/                    # Core orchestration
+│   ├── orchestrator.ts       # Main Agent class - coordinates phases
+│   ├── phases/               # Individual phase implementations
+│   ├── schemas.ts            # Zod schemas for LLM structured output
+│   ├── prompts.ts            # System prompts
+│   └── tool-executor.ts      # Tool selection & execution
+├── batch/                    # Batch mode (headless execution)
+│   ├── headless-runner.ts    # Run agent without UI, collect results
+│   └── types.ts              # BatchResult, TaskSummary types
+├── model/llm.ts              # Multi-provider LLM abstraction (OpenAI, Claude, Gemini, Ollama)
+├── tools/                    # Tool definitions
+│   ├── finance/              # Financial data tools (fundamentals, prices, filings, etc.)
+│   └── search/               # Web search (Tavily)
+├── components/               # React/Ink terminal UI components
+├── hooks/useAgentExecution.ts # React hook connecting agent to UI
+└── utils/
+    ├── context.ts            # Tool context manager (caching to .dexter/context/)
+    └── message-history.ts    # Conversation history management
+```
+
+### Core Patterns
+
+1. **Structured Output with Zod**: All LLM interactions use Zod schemas (`UnderstandingSchema`, `PlanSchema`, `ReflectionSchema`, etc.)
+
+2. **Multi-Provider LLM** (`getChatModel()` in `src/model/llm.ts`): Supports OpenAI (default), Anthropic (prefix: "claude-"), Google (prefix: "gemini-"), Ollama (prefix: "ollama:")
+
+3. **Deferred Tool Selection**: Tools are selected at execution time (not planning time) by a fast model (gpt-5-mini)
+
+4. **Callback-Based UI Updates**: Agent uses `AgentCallbacks` interface for real-time UI integration without tight coupling
+
+5. **Context Management**: `ToolContextManager` persists tool outputs to `.dexter/context/` using content-addressed storage (MD5 hash)
+
+### Adding New Financial Tools
+1. Create tool in `src/tools/finance/`
+2. Export from `src/tools/index.ts`
+
+### Environment Variables
+Required: `FINANCIAL_DATASETS_API_KEY`
+LLM keys (at least one): `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`
+Optional: `TAVILY_API_KEY` (web search), `OLLAMA_BASE_URL` (local models)

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "start": "bun run src/index.tsx",
     "dev": "bun --watch run src/index.tsx",
+    "batch": "bun run src/batch.ts",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
     "test:watch": "bun test --watch"

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env bun
+/**
+ * Batch mode entry point for Dexter.
+ *
+ * Usage:
+ *   bun batch tickers.txt
+ *   bun batch tickers.txt --template "Analyze {TICKER} growth"
+ *   bun batch tickers.txt --output ./research --model gpt-5.2
+ */
+import { config } from 'dotenv';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { basename, join } from 'path';
+
+import { runHeadless } from './batch/headless-runner.js';
+import { DEFAULT_TEMPLATE, type BatchResult } from './batch/types.js';
+import { getSetting } from './utils/config.js';
+import { DEFAULT_MODEL } from './model/llm.js';
+
+/**
+ * Generate a timestamped run ID for the output folder.
+ * Format: YYYY-MM-DD_HH-MM-SS
+ */
+function generateRunId(): string {
+  const now = new Date();
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}_${pad(now.getHours())}-${pad(now.getMinutes())}-${pad(now.getSeconds())}`;
+}
+
+// Load environment variables
+config({ quiet: true });
+
+interface Args {
+  inputFile: string;
+  outputDir: string;
+  template: string;
+  model: string;
+}
+
+function parseArgs(): Args {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+    console.log(`
+Dexter Batch Mode - Run financial research on multiple tickers
+
+Usage:
+  bun batch <tickers.txt> [options]
+
+Options:
+  --template <template>  Query template (use {TICKER} as placeholder)
+                         Default: "${DEFAULT_TEMPLATE}"
+  --output <dir>         Base output directory (default: ./outputs)
+                         Each run creates a timestamped subfolder
+  --model <model>        Model to use (default: saved model or gpt-5.2)
+  -h, --help             Show this help
+
+Output:
+  Each run creates: outputs/YYYY-MM-DD_HH-MM-SS/
+    - Individual files: AAPL.json, GOOGL.json, etc.
+    - Combined file: _combined.json (all results in one file)
+
+Examples:
+  bun batch tickers.txt
+  bun batch portfolio.txt --output ./research
+  bun batch tickers.txt --template "Analyze {TICKER} for dividend investing"
+`);
+    process.exit(0);
+  }
+
+  const inputFile = args[0];
+  let outputDir = './outputs';
+  let template = DEFAULT_TEMPLATE;
+  let model = getSetting('modelId', DEFAULT_MODEL) as string;
+
+  for (let i = 1; i < args.length; i++) {
+    if (args[i] === '--output' && args[i + 1]) {
+      outputDir = args[++i];
+    } else if (args[i] === '--template' && args[i + 1]) {
+      template = args[++i];
+    } else if (args[i] === '--model' && args[i + 1]) {
+      model = args[++i];
+    }
+  }
+
+  return { inputFile, outputDir, template, model };
+}
+
+function readTickers(filePath: string): string[] {
+  if (!existsSync(filePath)) {
+    console.error(`Error: File not found: ${filePath}`);
+    process.exit(1);
+  }
+
+  const content = readFileSync(filePath, 'utf-8');
+  return content
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line && !line.startsWith('#')); // Filter empty lines and comments
+}
+
+function formatDuration(ms: number): string {
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}m ${remainingSeconds}s`;
+}
+
+async function main() {
+  const { inputFile, outputDir: baseOutputDir, template, model } = parseArgs();
+
+  const tickers = readTickers(inputFile);
+
+  if (tickers.length === 0) {
+    console.error('Error: No tickers found in input file');
+    process.exit(1);
+  }
+
+  // Create timestamped output folder
+  const runId = generateRunId();
+  const outputDir = join(baseOutputDir, runId);
+
+  console.log(`\nDexter Batch Mode`);
+  console.log(`=================`);
+  console.log(`Input:    ${inputFile} (${tickers.length} tickers)`);
+  console.log(`Output:   ${outputDir}/`);
+  console.log(`Model:    ${model}`);
+  console.log(`Template: ${template.substring(0, 50)}${template.length > 50 ? '...' : ''}`);
+  console.log('');
+
+  // Create output directory
+  mkdirSync(outputDir, { recursive: true });
+
+  const runStats: { ticker: string; success: boolean; duration: number; error?: string }[] = [];
+  const batchResults: BatchResult[] = [];
+  const startTime = Date.now();
+
+  for (let i = 0; i < tickers.length; i++) {
+    const ticker = tickers[i];
+    const query = template.replace(/\{TICKER\}/g, ticker);
+    const progress = `[${i + 1}/${tickers.length}]`;
+
+    process.stdout.write(`${progress} ${ticker}... `);
+
+    try {
+      const result = await runHeadless({ ticker, query, model });
+
+      // Write individual JSON output
+      const outputPath = join(outputDir, `${ticker}.json`);
+      writeFileSync(outputPath, JSON.stringify(result, null, 2));
+
+      // Collect for combined output
+      batchResults.push(result);
+
+      console.log(`done (${formatDuration(result.metadata.durationMs)})`);
+      runStats.push({ ticker, success: true, duration: result.metadata.durationMs });
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      console.log(`failed - ${errorMsg}`);
+      runStats.push({ ticker, success: false, duration: 0, error: errorMsg });
+    }
+  }
+
+  // Write combined JSON with all results
+  const totalTime = Date.now() - startTime;
+  const combined = {
+    runId,
+    generatedAt: new Date().toISOString(),
+    inputFile: basename(inputFile),
+    model,
+    template,
+    tickerCount: batchResults.length,
+    tickers: batchResults.map(r => r.ticker),
+    totalDurationMs: totalTime,
+    results: batchResults,
+  };
+  writeFileSync(join(outputDir, '_combined.json'), JSON.stringify(combined, null, 2));
+
+  // Print summary
+  const successCount = runStats.filter(r => r.success).length;
+  const failCount = runStats.filter(r => !r.success).length;
+
+  console.log('');
+  console.log('Summary');
+  console.log('-------');
+  console.log(`Completed: ${successCount}/${tickers.length} tickers`);
+  if (failCount > 0) {
+    console.log(`Failed:    ${failCount} tickers`);
+    for (const r of runStats.filter(r => !r.success)) {
+      console.log(`  - ${r.ticker}: ${r.error}`);
+    }
+  }
+  console.log(`Total time: ${formatDuration(totalTime)}`);
+  console.log(`Output: ${outputDir}/`);
+  console.log(`Combined: ${outputDir}/_combined.json`);
+}
+
+main().catch(error => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/src/batch/headless-runner.ts
+++ b/src/batch/headless-runner.ts
@@ -1,0 +1,102 @@
+import { Agent, AgentCallbacks } from '../agent/orchestrator.js';
+import type { Task, Plan } from '../agent/state.js';
+import type { BatchResult, TaskSummary } from './types.js';
+import { tasksToSummary } from './types.js';
+
+export interface RunOptions {
+  ticker: string;
+  query: string;
+  model: string;
+}
+
+/**
+ * Runs the agent headlessly (without UI) and collects all results.
+ */
+export async function runHeadless(options: RunOptions): Promise<BatchResult> {
+  const { ticker, query, model } = options;
+  const startTime = new Date();
+
+  // Collect data from callbacks
+  const allTasks: Task[] = [];
+  let iterations = 0;
+  let answerStream: AsyncGenerator<string> | null = null;
+
+  const callbacks: AgentCallbacks = {
+    onPlanCreated: (plan: Plan) => {
+      // Merge tasks from each iteration
+      for (const task of plan.tasks) {
+        const existing = allTasks.find(t => t.id === task.id);
+        if (existing) {
+          Object.assign(existing, task);
+        } else {
+          allTasks.push({ ...task });
+        }
+      }
+    },
+
+    onTaskUpdate: (taskId: string, status) => {
+      const task = allTasks.find(t => t.id === taskId);
+      if (task) {
+        task.status = status;
+        if (status === 'in_progress' && !task.startTime) {
+          task.startTime = Date.now();
+        } else if (status === 'completed' || status === 'failed') {
+          task.endTime = Date.now();
+        }
+      }
+    },
+
+    onTaskToolCallsSet: (taskId, toolCalls) => {
+      const task = allTasks.find(t => t.id === taskId);
+      if (task) {
+        task.toolCalls = toolCalls;
+      }
+    },
+
+    onToolCallUpdate: (taskId, toolIndex, status, output, error) => {
+      const task = allTasks.find(t => t.id === taskId);
+      if (task?.toolCalls?.[toolIndex]) {
+        task.toolCalls[toolIndex].status = status;
+        if (output) task.toolCalls[toolIndex].output = output;
+        if (error) task.toolCalls[toolIndex].error = error;
+      }
+    },
+
+    onIterationStart: (iteration) => {
+      iterations = iteration;
+    },
+
+    onAnswerStream: (stream) => {
+      answerStream = stream;
+    },
+  };
+
+  // Run the agent
+  const agent = new Agent({ model, callbacks });
+  await agent.run(query);
+
+  // Collect the answer from the stream
+  let answer = '';
+  if (answerStream !== null) {
+    const stream = answerStream as AsyncGenerator<string>;
+    for await (const chunk of stream) {
+      answer += chunk;
+    }
+  }
+
+  const endTime = new Date();
+
+  return {
+    ticker,
+    query,
+    answer,
+    tasks: tasksToSummary(allTasks),
+    metadata: {
+      model,
+      startTime: startTime.toISOString(),
+      endTime: endTime.toISOString(),
+      durationMs: endTime.getTime() - startTime.getTime(),
+      iterations,
+    },
+  };
+}

--- a/src/batch/types.ts
+++ b/src/batch/types.ts
@@ -1,0 +1,70 @@
+import type { Task, ToolCallStatus } from '../agent/state.js';
+
+/**
+ * Summary of a task for batch output.
+ */
+export interface TaskSummary {
+  id: string;
+  description: string;
+  taskType: 'use_tools' | 'reason';
+  status: 'completed' | 'failed';
+  toolCalls?: {
+    tool: string;
+    args: Record<string, unknown>;
+    status: 'completed' | 'failed';
+  }[];
+  durationMs?: number;
+}
+
+/**
+ * Result of a single batch research query.
+ */
+export interface BatchResult {
+  ticker: string;
+  query: string;
+  answer: string;
+  tasks: TaskSummary[];
+  metadata: {
+    model: string;
+    startTime: string;
+    endTime: string;
+    durationMs: number;
+    iterations: number;
+  };
+}
+
+/**
+ * Options for batch processing.
+ */
+export interface BatchOptions {
+  inputFile: string;
+  outputDir: string;
+  template: string;
+  model: string;
+}
+
+/**
+ * Default query template for financial research.
+ */
+export const DEFAULT_TEMPLATE =
+  'Investigate fundamentals of {TICKER} and determine whether a sensible investment thesis can be defended';
+
+/**
+ * Converts Task[] to TaskSummary[] for JSON output.
+ */
+export function tasksToSummary(tasks: Task[]): TaskSummary[] {
+  return tasks.map(task => ({
+    id: task.id,
+    description: task.description,
+    taskType: task.taskType ?? 'use_tools',
+    status: task.status === 'completed' ? 'completed' : 'failed',
+    toolCalls: task.toolCalls?.map(tc => ({
+      tool: tc.tool,
+      args: tc.args,
+      status: tc.status === 'completed' ? 'completed' : 'failed',
+    })),
+    durationMs: task.startTime && task.endTime
+      ? task.endTime - task.startTime
+      : undefined,
+  }));
+}


### PR DESCRIPTION
## Summary
- New `bun batch <tickers.txt>` command for headless batch processing
- Supports custom query templates with `{TICKER}` placeholder  
- Each run creates timestamped output folder (`outputs/YYYY-MM-DD_HH-MM-SS/`)
- Generates individual JSON files per ticker + combined `_combined.json`
- JSON output includes: query, answer, tasks with tool calls, metadata

## Usage
```bash
bun batch tickers.txt
bun batch tickers.txt --template "Analyze {TICKER} growth"
bun batch tickers.txt --output ./research
```

## Output Structure
```
outputs/2025-01-12_14-30-45/
├── AAPL.json
├── GOOGL.json
├── NVDA.json
└── _combined.json   # All results in one file for LLM consumption
```

## Test Plan
- [x] Tested with 41 tickers (~58 min total run)
- [x] Verified JSON output structure
- [x] Verified `_combined.json` generation
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.ai/code)