### PR TITLE
Custom provider option add

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -11,6 +11,7 @@ import { Input } from './components/Input.js';
 import { Intro } from './components/Intro.js';
 import { ProviderSelector, ModelSelector } from './components/ModelSelector.js';
 import { ApiKeyConfirm, ApiKeyInput } from './components/ApiKeyPrompt.js';
+import { CustomProviderPrompt } from './components/CustomProviderPrompt.js';
 import { DebugPanel } from './components/DebugPanel.js';
 import { HistoryItemView, WorkingIndicator } from './components/index.js';
 import { getApiKeyNameForProvider, getProviderDisplayName } from './utils/env.js';
@@ -37,6 +38,7 @@ export function CLI() {
     handleModelSelect,
     handleApiKeyConfirm,
     handleApiKeySubmit,
+    handleCustomProviderSubmit,
     isInSelectionFlow,
   } = useModelSelection((errorMsg) => setError(errorMsg));
   
@@ -170,6 +172,14 @@ export function CLI() {
           apiKeyName={apiKeyName}
           onSubmit={handleApiKeySubmit} 
         />
+      </Box>
+    );
+  }
+  
+  if (appState === 'custom_provider_config') {
+    return (
+      <Box flexDirection="column">
+        <CustomProviderPrompt onSubmit={handleCustomProviderSubmit} />
       </Box>
     );
   }

--- a/src/components/CustomProviderPrompt.tsx
+++ b/src/components/CustomProviderPrompt.tsx
@@ -1,0 +1,115 @@
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import TextInput from 'ink-text-input';
+import { colors } from '../theme.js';
+
+type ConfigStep = 'name' | 'baseUrl' | 'apiKey' | 'modelId';
+
+interface CustomProviderPromptProps {
+  onSubmit: (config: {
+    name: string;
+    baseUrl: string;
+    apiKey: string;
+    modelId: string;
+  } | null) => void;
+}
+
+export function CustomProviderPrompt({ onSubmit }: CustomProviderPromptProps) {
+  const [step, setStep] = useState<ConfigStep>('name');
+  const [name, setName] = useState('');
+  const [baseUrl, setBaseUrl] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [modelId, setModelId] = useState('');
+  const [inputValue, setInputValue] = useState('');
+
+  useInput((input, key) => {
+    if (key.escape) {
+      onSubmit(null);
+    }
+  });
+
+  const handleSubmit = (value: string) => {
+    if (!value.trim()) {
+      return;
+    }
+
+    switch (step) {
+      case 'name':
+        setName(value);
+        setInputValue('');
+        setStep('baseUrl');
+        break;
+      case 'baseUrl':
+        setBaseUrl(value);
+        setInputValue('');
+        setStep('apiKey');
+        break;
+      case 'apiKey':
+        setApiKey(value);
+        setInputValue('');
+        setStep('modelId');
+        break;
+      case 'modelId':
+        setModelId(value);
+        onSubmit({
+          name,
+          baseUrl,
+          apiKey,
+          modelId: value,
+        });
+        break;
+    }
+  };
+
+  const getPromptText = (): string => {
+    switch (step) {
+      case 'name':
+        return 'Enter provider name (e.g., "Groq", "Together AI"):';
+      case 'baseUrl':
+        return 'Enter base URL (e.g., "https://api.groq.com/openai/v1"):';
+      case 'apiKey':
+        return 'Enter API key:';
+      case 'modelId':
+        return 'Enter model ID (e.g., "mixtral-8x7b-32768"):';
+    }
+  };
+
+  const getExampleText = (): string => {
+    switch (step) {
+      case 'name':
+        return 'Examples: Groq, Together AI, Perplexity, OpenRouter';
+      case 'baseUrl':
+        return 'Must be OpenAI-compatible endpoint (usually ends with /v1)';
+      case 'apiKey':
+        return 'Your API key will be stored in .dexter/settings.json';
+      case 'modelId':
+        return 'Check your provider\'s documentation for available models';
+    }
+  };
+
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text color={colors.primary} bold>
+        Configure Custom Provider
+      </Text>
+      <Box marginTop={1}>
+        <Text color={colors.muted}>{getExampleText()}</Text>
+      </Box>
+      <Box marginTop={1} flexDirection="column">
+        <Text color={colors.primary}>{getPromptText()}</Text>
+        <Box marginTop={1}>
+          <Text color={colors.primary} bold>{'> '}</Text>
+          <TextInput
+            value={inputValue}
+            onChange={setInputValue}
+            onSubmit={handleSubmit}
+            mask={step === 'apiKey' ? '*' : undefined}
+          />
+        </Box>
+      </Box>
+      <Box marginTop={1}>
+        <Text color={colors.muted}>esc to cancel</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/ModelSelector.tsx
+++ b/src/components/ModelSelector.tsx
@@ -34,6 +34,11 @@ const PROVIDERS: Provider[] = [
     providerId: 'ollama',
     models: [], // Populated dynamically from local Ollama API
   },
+  {
+    displayName: 'Custom (OpenAI-compatible)',
+    providerId: 'custom',
+    models: [], // Configured by user
+  },
 ];
 
 export function getModelsForProvider(providerId: string): string[] {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,6 +3,7 @@ export { Input } from './Input.js';
 export { AnswerBox, UserQuery } from './AnswerBox.js';
 export { ProviderSelector, ModelSelector, PROVIDERS, getModelsForProvider, getDefaultModelForProvider, getProviderIdForModel } from './ModelSelector.js';
 export { ApiKeyConfirm, ApiKeyInput } from './ApiKeyPrompt.js';
+export { CustomProviderPrompt } from './CustomProviderPrompt.js';
 export { DebugPanel } from './DebugPanel.js';
 
 // V2 components

--- a/src/hooks/useModelSelection.ts
+++ b/src/hooks/useModelSelection.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef } from 'react';
-import { getSetting, setSetting } from '../utils/config.js';
+import { getSetting, setSetting, saveCustomProviderConfig, CustomProviderConfig } from '../utils/config.js';
 import { getProviderDisplayName, checkApiKeyExistsForProvider, saveApiKeyForProvider } from '../utils/env.js';
 import { getModelsForProvider, getDefaultModelForProvider } from '../components/ModelSelector.js';
 import { getOllamaModels } from '../utils/ollama.js';
@@ -10,7 +10,7 @@ import { InMemoryChatHistory } from '../utils/in-memory-chat-history.js';
 // Types
 // ============================================================================
 
-const SELECTION_STATES = ['provider_select', 'model_select', 'api_key_confirm', 'api_key_input'] as const;
+const SELECTION_STATES = ['provider_select', 'model_select', 'api_key_confirm', 'api_key_input', 'custom_provider_config'] as const;
 type SelectionState = typeof SELECTION_STATES[number];
 type AppState = 'idle' | SelectionState;
 
@@ -34,6 +34,7 @@ export interface UseModelSelectionResult {
   handleModelSelect: (modelId: string | null) => void;
   handleApiKeyConfirm: (wantsToSet: boolean) => void;
   handleApiKeySubmit: (apiKey: string | null) => void;
+  handleCustomProviderSubmit: (config: CustomProviderConfig | null) => void;
   
   // Helpers
   isInSelectionFlow: () => boolean;
@@ -111,6 +112,12 @@ export function useModelSelection(
   const handleProviderSelect = useCallback(async (providerId: string | null) => {
     if (providerId) {
       setPendingProvider(providerId);
+      
+      // For custom provider, go directly to configuration
+      if (providerId === 'custom') {
+        setAppState('custom_provider_config');
+        return;
+      }
       
       // Fetch models for the provider
       if (providerId === 'ollama') {
@@ -190,6 +197,22 @@ export function useModelSelection(
     }
   }, [pendingProvider, pendingModels, completeModelSwitch, resetPendingState, onError]);
   
+  // Custom provider configuration submit handler
+  const handleCustomProviderSubmit = useCallback((config: CustomProviderConfig | null) => {
+    if (config) {
+      const saved = saveCustomProviderConfig(config);
+      if (saved) {
+        completeModelSwitch('custom', `custom:${config.modelId}`);
+      } else {
+        onError('Failed to save custom provider configuration.');
+        resetPendingState();
+      }
+    } else {
+      // User cancelled
+      resetPendingState();
+    }
+  }, [completeModelSwitch, resetPendingState, onError]);
+  
   return {
     selectionState: {
       appState,
@@ -205,6 +228,7 @@ export function useModelSelection(
     handleModelSelect,
     handleApiKeyConfirm,
     handleApiKeySubmit,
+    handleCustomProviderSubmit,
     isInSelectionFlow,
   };
 }

--- a/src/model/llm.ts
+++ b/src/model/llm.ts
@@ -8,6 +8,7 @@ import { StructuredToolInterface } from '@langchain/core/tools';
 import { Runnable } from '@langchain/core/runnables';
 import { z } from 'zod';
 import { DEFAULT_SYSTEM_PROMPT } from '@/agent/prompts';
+import { getCustomProviderConfig } from '@/utils/config';
 
 export const DEFAULT_PROVIDER = 'openai';
 export const DEFAULT_MODEL = 'gpt-5.2';
@@ -84,6 +85,20 @@ const MODEL_PROVIDERS: Record<string, ModelFactory> = {
       ...opts,
       ...(process.env.OLLAMA_BASE_URL ? { baseUrl: process.env.OLLAMA_BASE_URL } : {}),
     }),
+  'custom:': (name, opts) => {
+    const customConfig = getCustomProviderConfig();
+    if (!customConfig) {
+      throw new Error('Custom provider not configured');
+    }
+    return new ChatOpenAI({
+      model: customConfig.modelId,
+      ...opts,
+      apiKey: customConfig.apiKey,
+      configuration: {
+        baseURL: customConfig.baseUrl,
+      },
+    });
+  },
 };
 
 const DEFAULT_MODEL_FACTORY: ModelFactory = (name, opts) =>

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -10,10 +10,18 @@ const MODEL_TO_PROVIDER_MAP: Record<string, string> = {
   'gemini-3': 'google',
 };
 
+export interface CustomProviderConfig {
+  name: string;
+  baseUrl: string;
+  apiKey: string;
+  modelId: string;
+}
+
 interface Config {
   provider?: string;
   modelId?: string;  // Selected model ID (e.g., "gpt-5.2", "ollama:llama3.1")
   model?: string;    // Legacy key, kept for migration
+  customProviderConfig?: CustomProviderConfig;
   [key: string]: unknown;
 }
 
@@ -87,5 +95,24 @@ export function setSetting(key: string, value: unknown): boolean {
     delete config.model;
   }
   
+  return saveConfig(config);
+}
+
+export function getCustomProviderConfig(): CustomProviderConfig | null {
+  const config = loadConfig();
+  return config.customProviderConfig || null;
+}
+
+export function saveCustomProviderConfig(customConfig: CustomProviderConfig): boolean {
+  const config = loadConfig();
+  config.customProviderConfig = customConfig;
+  config.provider = 'custom';
+  config.modelId = `custom:${customConfig.modelId}`;
+  return saveConfig(config);
+}
+
+export function clearCustomProviderConfig(): boolean {
+  const config = loadConfig();
+  delete config.customProviderConfig;
   return saveConfig(config);
 }

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -14,7 +14,9 @@ const PROVIDERS: Record<string, ProviderConfig> = {
   openai: { displayName: 'OpenAI', apiKeyEnvVar: 'OPENAI_API_KEY' },
   anthropic: { displayName: 'Anthropic', apiKeyEnvVar: 'ANTHROPIC_API_KEY' },
   google: { displayName: 'Google', apiKeyEnvVar: 'GOOGLE_API_KEY' },
+  xai: { displayName: 'xAI', apiKeyEnvVar: 'XAI_API_KEY' },
   ollama: { displayName: 'Ollama' },
+  custom: { displayName: 'Custom' },
 };
 
 export function getApiKeyNameForProvider(providerId: string): string | undefined {


### PR DESCRIPTION
# Add Support for Custom OpenAI-Compatible Providers

## Description

This PR adds the ability to use **any OpenAI-compatible API provider** with Dexter, including providers like Groq, Together AI, OpenRouter or self deployed models using vLLM or llama.cpp

Previously, Dexter only supported hardcoded providers (OpenAI, Anthropic, Google, xAI, Ollama). Now users can configure custom providers through an interactive CLI flow without modifying code.

## Changes

### Core Implementation

- **`src/utils/config.ts`**: Added `CustomProviderConfig` interface and functions to save/load custom provider configurations
- **`src/model/llm.ts`**: Added `custom:` prefix handler that loads provider settings from config and creates ChatOpenAI client with custom base URL
- **`src/utils/env.ts`**: Added custom provider to provider registry
- **`src/components/CustomProviderPrompt.tsx`**: New component - interactive 4-step wizard for configuring custom providers
- **`src/components/ModelSelector.tsx`**: Added "Custom (OpenAI-compatible)" option to provider list
- **`src/hooks/useModelSelection.ts`**: Added `custom_provider_config` state and `handleCustomProviderSubmit` handler
- **`src/cli.tsx`**: Added rendering for custom provider configuration screen

### User Experience

1. User types `/model` command
2. Selects "Custom (OpenAI-compatible)" from provider list
3. Enters provider details through guided prompts:
   - Provider name (display name)
   - Base URL (API endpoint)
   - API key
   - Model ID
4. Configuration persists in `.dexter/settings.json`

<img width="1071" height="785" alt="image" src="https://github.com/user-attachments/assets/b5bd5a82-5a3b-41e6-9565-9f07bdd72e9b" />


### Configuration Storage

Custom provider settings are stored locally in `.dexter/settings.json`:
```json
{
  "provider": "custom",
  "modelId": "custom:mixtral-8x7b-32768",
  "customProviderConfig": {
    "name": "Groq",
    "baseUrl": "https://api.groq.com/openai/v1",
    "apiKey": "gsk_...",
    "modelId": "mixtral-8x7b-32768"
  }
}
```

## Related Issues

Closes https://github.com/virattt/dexter/issues/49
