### PR TITLE
feat: add CI/CD pipeline for automated testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules/
+.git/
+.gitignore
+.env
+.env.*
+*.md
+.vscode/
+.idea/
+.cursor/
+.dexter/
+coverage/
+logs/
+*.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run type check
+        run: bun run typecheck
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun test
+
+  docker:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: dexter:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM oven/bun:1 AS base
+WORKDIR /app
+
+FROM base AS deps
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile
+
+FROM deps AS build
+COPY . .
+RUN bun run typecheck
+
+FROM base AS release
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+USER bun
+ENTRYPOINT ["bun", "run", "start"]


### PR DESCRIPTION
## What this PR does

This adds a CI/CD pipeline so that every push and pull request automatically runs checks before merging.

## Changes

- **GitHub Actions workflow** (`.github/workflows/ci.yml`)
  - Runs type checking with `bun run typecheck`
  - Runs tests with `bun test`
  - Builds Docker image to make sure it works

- **Dockerfile** - Multi-stage build using the official Bun image

- **.dockerignore** - Keeps the Docker image small by excluding unnecessary files

## Why this matters

Right now, there's no automated way to catch bugs before they get merged. This means broken code can slip through. With this CI pipeline:

- PRs won't merge if they break the build
- Docker builds are tested automatically
- Everyone can see if their code passes checks

## Testing

I tested all three jobs locally:
- ✅ `bun test` - passes (no tests exist yet, but exits cleanly)
- ✅ `docker build` - image builds successfully
- ⚠️ `bun run typecheck` - found 2 pre-existing type errors in the codebase (unrelated to this PR)

Closes #41
