### PR TITLE
fix: Fix app exiting immediately on startup

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,5 +7,7 @@ import { CLI } from './cli.js';
 // Load environment variables
 config({ quiet: true });
 
-// Render the CLI app
-render(<CLI />);
+// Render the CLI app and wait for it to exit
+// This keeps the process alive until the user exits
+const { waitUntilExit } = render(<CLI />);
+await waitUntilExit();


### PR DESCRIPTION
## Summary

Fixes the app exiting immediately when running `bun start` or `bun dev`, particularly in VSCode's integrated terminal.

Fixes #73

## Problem

The `render()` function from Ink returns immediately without blocking. Without awaiting `waitUntilExit()`, the process has nothing keeping it alive and exits right after rendering.

## Solution

Call `waitUntilExit()` on the render instance and await it. This Promise only resolves when the app is unmounted (via `exit()` or Ctrl+C), keeping the process alive for the duration of the session.

```diff
-render(<CLI />);
+const { waitUntilExit } = render(<CLI />);
+await waitUntilExit();
```

## Reference

From the [official Ink documentation](https://github.com/vadimdemedes/ink#waituntilexit)

## Testing

- `bun start` - app stays running ✓
- `bun dev` - watch mode works ✓
- Tested in VSCode integrated terminal ✓
- Exit via `exit`/`quit` command works ✓
- Exit via Ctrl+C works ✓