### PR TITLE
feat(tools): Add IPO Astrology Tool (Alternative Data Analysis)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "ink-spinner": "^5.0.0",
         "ink-text-input": "^6.0.0",
         "langsmith": "^0.4.10",
+        "lunar-javascript": "^1.7.7",
         "react": "^19.2.0",
         "zod": "^4.1.13",
       },
@@ -671,6 +672,8 @@
     "lodash.memoize": ["lodash.memoize@4.1.2", "", {}, "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "lunar-javascript": ["lunar-javascript@1.7.7", "", {}, "sha512-u/KYiwPIBo/0bT+WWfU7qO1d+aqeB90Tuy4ErXenr2Gam0QcWeezUvtiOIyXR7HbVnW2I1DKfU0NBvzMZhbVQw=="],
 
     "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",
     "langsmith": "^0.4.10",
+    "lunar-javascript": "^1.7.7",
     "react": "^19.2.0",
     "zod": "^4.1.13"
   },

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -5,6 +5,7 @@ export type { RegisteredTool } from './registry.js';
 // Individual tool exports (for backward compatibility and direct access)
 export { createFinancialSearch } from './finance/index.js';
 export { tavilySearch } from './search/index.js';
+export { ipoAstrology, createIpoAstrology, IPO_ASTROLOGY_DESCRIPTION } from './ipoAstrology.js';
 
 // Tool descriptions
 export {

--- a/src/tools/ipoAstrology.ts
+++ b/src/tools/ipoAstrology.ts
@@ -1,0 +1,246 @@
+/**
+ * IPO Astrology Tool - Alternative Data Analysis
+ *
+ * "Standard quantitative analysis is great, but markets are irrational."
+ *
+ * This experimental tool adds a "Metaphysical Sentiment" layer by analyzing
+ * the WuXing (Five Elements) interactions of a company's IPO date against
+ * the current year using Chinese Metaphysics (BaZi/Five Elements).
+ *
+ * Cyber-Mysticism: Serious implementation of a "fun" concept.
+ *
+ * Uses `lunar-javascript` for precise astronomical calculation.
+ */
+
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+import { Solar } from 'lunar-javascript';
+
+// Heavenly Stems (天干) to WuXing (Five Elements) mapping
+const STEM_TO_ELEMENT: Record<string, string> = {
+  '甲': 'Wood',
+  '乙': 'Wood',
+  '丙': 'Fire',
+  '丁': 'Fire',
+  '戊': 'Earth',
+  '己': 'Earth',
+  '庚': 'Metal',
+  '辛': 'Metal',
+  '壬': 'Water',
+  '癸': 'Water',
+};
+
+// WuXing element names in Chinese for output
+const ELEMENT_CHINESE: Record<string, string> = {
+  'Wood': '木',
+  'Fire': '火',
+  'Earth': '土',
+  'Metal': '金',
+  'Water': '水',
+};
+
+// Generating cycle (生): A -> B means A generates B
+// Wood → Fire → Earth → Metal → Water → Wood
+const GENERATES: Record<string, string> = {
+  'Wood': 'Fire',
+  'Fire': 'Earth',
+  'Earth': 'Metal',
+  'Metal': 'Water',
+  'Water': 'Wood',
+};
+
+// Overcoming cycle (克): A -> B means A overcomes B
+// Wood → Earth → Water → Fire → Metal → Wood
+const OVERCOMES: Record<string, string> = {
+  'Wood': 'Earth',
+  'Earth': 'Water',
+  'Water': 'Fire',
+  'Fire': 'Metal',
+  'Metal': 'Wood',
+};
+
+/**
+ * Analyze the WuXing interaction between two elements
+ */
+function analyzeInteraction(
+  currentYearElement: string,
+  dayMasterElement: string
+): { type: 'harmony' | 'conflict' | 'support' | 'drain' | 'peer'; description: string } {
+  // Harmony: Current year generates Day Master (beneficial)
+  if (GENERATES[currentYearElement] === dayMasterElement) {
+    return {
+      type: 'harmony',
+      description: `${currentYearElement} generates ${dayMasterElement} → supportive energy, favorable conditions`,
+    };
+  }
+
+  // Conflict: Current year overcomes Day Master (challenging)
+  if (OVERCOMES[currentYearElement] === dayMasterElement) {
+    return {
+      type: 'conflict',
+      description: `${currentYearElement} overcomes ${dayMasterElement} → external pressure indicated`,
+    };
+  }
+
+  // Support: Day Master generates Current Year (draining energy from company)
+  if (GENERATES[dayMasterElement] === currentYearElement) {
+    return {
+      type: 'drain',
+      description: `${dayMasterElement} generates ${currentYearElement} → energy expenditure, output-focused year`,
+    };
+  }
+
+  // Counter: Day Master overcomes Current Year (company exerts control)
+  if (OVERCOMES[dayMasterElement] === currentYearElement) {
+    return {
+      type: 'support',
+      description: `${dayMasterElement} overcomes ${currentYearElement} → assertive positioning, competitive advantage`,
+    };
+  }
+
+  // Same element: peer relationship
+  return {
+    type: 'peer',
+    description: `Both ${currentYearElement} → peer energy, competition and collaboration`,
+  };
+}
+
+/**
+ * Get the Heavenly Stem element for a given date
+ */
+function getDayMasterElement(year: number, month: number, day: number): { stem: string; element: string } {
+  const solar = Solar.fromYmd(year, month, day);
+  const lunar = solar.getLunar();
+  const eightChar = lunar.getEightChar();
+  const dayGan = eightChar.getDayGan();
+
+  return {
+    stem: dayGan,
+    element: STEM_TO_ELEMENT[dayGan] || 'Unknown',
+  };
+}
+
+/**
+ * Get the current BaZi year's Heavenly Stem element (uses 立春 Lichun as year boundary)
+ */
+function getCurrentYearElement(): { year: number; stem: string; element: string } {
+  const now = new Date();
+  const solar = Solar.fromYmd(now.getFullYear(), now.getMonth() + 1, now.getDate());
+  const lunar = solar.getLunar();
+
+  // getYearGanExact uses 立春 (Start of Spring) as the year boundary
+  // This is the traditional BaZi year calculation method
+  const yearGan = lunar.getYearGanExact();
+
+  return {
+    year: now.getFullYear(),
+    stem: yearGan,
+    element: STEM_TO_ELEMENT[yearGan] || 'Unknown',
+  };
+}
+
+// Tool description for system prompt injection
+export const IPO_ASTROLOGY_DESCRIPTION = `\
+**IPO Astrology Tool** - Alternative Data / Metaphysical Sentiment Analysis
+
+Analyzes a company's IPO date using Chinese Metaphysics (BaZi/Five Elements) to provide
+an esoteric perspective on the company's "elemental nature" and its interaction with
+the current year's energy.
+
+**When to use:**
+- When the user asks for "alternative data" or unconventional analysis
+- To add a cultural/esoteric dimension to financial research
+- For experimental/exploratory analysis alongside traditional metrics
+
+**When NOT to use:**
+- As a primary investment decision tool (this is supplementary/experimental)
+- When the user explicitly wants only quantitative analysis
+
+**Input:**
+- ticker: Company ticker symbol (e.g., "TSLA")
+- ipoDate: IPO date in YYYY-MM-DD format (e.g., "2010-06-29")
+
+**Output:**
+A summary including:
+- Day Master element (company's "Self" based on IPO date)
+- Current BaZi Year element
+- WuXing interaction analysis (Harmony/Conflict/Support/Drain/Peer)
+- Interpretation with metaphysical guidance
+
+**Note:** Uses lunar-javascript for precise astronomical calculation with traditional
+立春 (Lichun/Start of Spring) year boundary.`;
+
+export const ipoAstrology = new DynamicStructuredTool({
+  name: 'ipo_astrology',
+  description:
+    'Analyze a company IPO date using Chinese Metaphysics (BaZi/Five Elements) for alternative/esoteric sentiment analysis.',
+  schema: z.object({
+    ticker: z.string().describe('Company ticker symbol (e.g., "TSLA", "AAPL")'),
+    ipoDate: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format')
+      .describe('IPO date in YYYY-MM-DD format (e.g., "2010-06-29")'),
+  }),
+  func: async (input) => {
+    const { ticker, ipoDate } = input;
+
+    // Parse IPO date
+    const [yearStr, monthStr, dayStr] = ipoDate.split('-');
+    const year = parseInt(yearStr, 10);
+    const month = parseInt(monthStr, 10);
+    const day = parseInt(dayStr, 10);
+
+    // Validate date
+    if (isNaN(year) || isNaN(month) || isNaN(day)) {
+      return `Error: Invalid date format. Please provide date as YYYY-MM-DD.`;
+    }
+
+    try {
+      // Get Day Master (company's "Self")
+      const dayMaster = getDayMasterElement(year, month, day);
+
+      // Get Current Year's element
+      const currentYear = getCurrentYearElement();
+
+      // Analyze interaction
+      const interaction = analyzeInteraction(currentYear.element, dayMaster.element);
+
+      // Format output
+      const interactionEmoji =
+        interaction.type === 'harmony'
+          ? '🌱'
+          : interaction.type === 'conflict'
+            ? '⚡'
+            : interaction.type === 'support'
+              ? '💪'
+              : interaction.type === 'drain'
+                ? '💨'
+                : '🤝';
+
+      const summary = [
+        `**${ticker.toUpperCase()} - IPO Astrology Analysis**`,
+        ``,
+        `📅 IPO Date: ${ipoDate}`,
+        `🏷️ Day Master: ${dayMaster.stem} (${dayMaster.element}/${ELEMENT_CHINESE[dayMaster.element]})`,
+        `📆 Current BaZi Year (${currentYear.year}): ${currentYear.stem} (${currentYear.element}/${ELEMENT_CHINESE[currentYear.element]})`,
+        ``,
+        `${interactionEmoji} **Interaction: ${interaction.type.charAt(0).toUpperCase() + interaction.type.slice(1)}**`,
+        `${interaction.description}`,
+        ``,
+        `---`,
+        `*Note: This is experimental alternative data analysis using Chinese Metaphysics.*`,
+        `*WuXing cycles: Wood→Fire→Earth→Metal→Water→Wood (生 generates)*`,
+        `*Wood→Earth→Water→Fire→Metal→Wood (克 overcomes)*`,
+      ].join('\n');
+
+      return summary;
+    } catch (error) {
+      return `Error analyzing IPO date: ${error instanceof Error ? error.message : 'Unknown error'}`;
+    }
+  },
+});
+
+// Factory function for consistency with other tools
+export function createIpoAstrology(): DynamicStructuredTool {
+  return ipoAstrology;
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -2,6 +2,7 @@ import { StructuredToolInterface } from '@langchain/core/tools';
 import { createFinancialSearch } from './finance/index.js';
 import { exaSearch, tavilySearch } from './search/index.js';
 import { skillTool, SKILL_TOOL_DESCRIPTION } from './skill.js';
+import { ipoAstrology, IPO_ASTROLOGY_DESCRIPTION } from './ipoAstrology.js';
 import { FINANCIAL_SEARCH_DESCRIPTION, WEB_SEARCH_DESCRIPTION } from './descriptions/index.js';
 import { discoverSkills } from '../skills/index.js';
 
@@ -57,6 +58,13 @@ export function getToolRegistry(model: string): RegisteredTool[] {
       description: SKILL_TOOL_DESCRIPTION,
     });
   }
+
+  // Include IPO Astrology tool (Alternative Data / Metaphysical Sentiment)
+  tools.push({
+    name: 'ipo_astrology',
+    tool: ipoAstrology,
+    description: IPO_ASTROLOGY_DESCRIPTION,
+  });
 
   return tools;
 }

--- a/src/types/lunar-javascript.d.ts
+++ b/src/types/lunar-javascript.d.ts
@@ -1,0 +1,52 @@
+/**
+ * Type declarations for lunar-javascript
+ * @see https://github.com/6tail/lunar-javascript
+ */
+
+declare module 'lunar-javascript' {
+  export class Solar {
+    static fromYmd(year: number, month: number, day: number): Solar;
+    getLunar(): Lunar;
+    getYear(): number;
+    getMonth(): number;
+    getDay(): number;
+  }
+
+  export class Lunar {
+    getEightChar(): EightChar;
+    getYearGan(): string;
+    getYearZhi(): string;
+    getYearGanExact(): string;
+    getYearZhiExact(): string;
+    getMonthGan(): string;
+    getMonthZhi(): string;
+    getDayGan(): string;
+    getDayZhi(): string;
+    getTimeGan(): string;
+    getTimeZhi(): string;
+    getYear(): number;
+    getMonth(): number;
+    getDay(): number;
+  }
+
+  export class EightChar {
+    static fromLunar(lunar: Lunar): EightChar;
+    getYear(): string;
+    getMonth(): string;
+    getDay(): string;
+    getTime(): string;
+    getYearGan(): string;
+    getYearZhi(): string;
+    getMonthGan(): string;
+    getMonthZhi(): string;
+    getDayGan(): string;
+    getDayZhi(): string;
+    getTimeGan(): string;
+    getTimeZhi(): string;
+  }
+
+  export class LunarUtil {
+    static WU_XING_GAN: Record<string, string>;
+    static WU_XING_ZHI: Record<string, string>;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a new `ipo_astrology` tool that analyzes a company's IPO date using Chinese Metaphysics (BaZi/Five Elements)
- Provides an esoteric "Metaphysical Sentiment" layer for alternative data analysis
- Uses `lunar-javascript` for precise astronomical calculations with traditional 立春 (Lichun) year boundary

## What it does

Standard quantitative analysis is great, but markets are irrational. This tool adds a "Metaphysical Sentiment" layer by analyzing the WuXing (Five Elements) interactions of a company's IPO date against the current year.

**Input:**
- `ticker`: Company ticker symbol (e.g., "TSLA")
- `ipoDate`: IPO date in YYYY-MM-DD format

**Output:**
- Day Master element (company's "Self" based on IPO date)
- Current BaZi Year element
- WuXing interaction analysis (Harmony/Conflict/Support/Drain/Peer)
- Interpretation with metaphysical guidance

## Files changed

- `src/tools/ipoAstrology.ts` - New tool implementation
- `src/tools/registry.ts` - Tool registration
- `src/tools/index.ts` - Exports
- `src/types/lunar-javascript.d.ts` - TypeScript declarations
- `package.json` / `bun.lock` - Added `lunar-javascript` dependency

## Test plan

- [ ] Run `bun run typecheck` to verify TypeScript compilation
- [ ] Test tool with sample IPO dates (e.g., TSLA: 2010-06-29, AAPL: 1980-12-12)
- [ ] Verify WuXing interaction logic produces expected results

---

*Cyber-Mysticism: Serious implementation of a "fun" concept.*