### PR TITLE
docs: Fix Exa API key name to match code

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ bun install
 
 3. Set up your environment variables:
 ```bash
-# Copy the example environment file (from parent directory)
+# Copy the example environment file
 cp env.example .env
 
 # Edit .env and add your API keys (if using cloud providers)
@@ -80,7 +80,7 @@ cp env.example .env
 # FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
 
 # Web Search (Exa preferred, Tavily fallback)
-# EXA_API_KEY=your-exa-api-key
+# EXASEARCH_API_KEY=your-exa-api-key
 # TAVILY_API_KEY=your-tavily-api-key
 ```
 

--- a/env.example
+++ b/env.example
@@ -11,7 +11,7 @@ OLLAMA_BASE_URL=http://127.0.0.1:11434
 FINANCIAL_DATASETS_API_KEY=your-api-key
 
 # Web Search API Keys (Exa preferred, Tavily fallback)
-EXA_API_KEY=your-api-key
+EXASEARCH_API_KEY=your-api-key
 TAVILY_API_KEY=your-api-key
 
 # LangSmith 


### PR DESCRIPTION
## Summary
- Fix env var name mismatch: docs said `EXA_API_KEY` but code reads `EXASEARCH_API_KEY`
- Remove misleading "from parent directory" comment in README

## Test plan
- [ ] Follow README setup instructions with `EXASEARCH_API_KEY` set
- [ ] Verify Exa web search works correctly