### PR TITLE
fix: Handle search provider errors gracefully

### DIFF
--- a/src/tools/search/exa.ts
+++ b/src/tools/search/exa.ts
@@ -26,8 +26,13 @@ export const exaSearch = new DynamicStructuredTool({
     query: z.string().describe('The search query to look up on the web'),
   }),
   func: async (input) => {
-    const result = await getExaTool().invoke(input.query);
-    const { parsed, urls } = parseSearchResults(result);
-    return formatToolResult(parsed, urls);
+    try {
+      const result = await getExaTool().invoke(input.query);
+      const { parsed, urls } = parseSearchResults(result);
+      return formatToolResult(parsed, urls);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Search failed';
+      return formatToolResult({ error: errorMessage }, []);
+    }
   },
 });

--- a/src/tools/search/tavily.ts
+++ b/src/tools/search/tavily.ts
@@ -21,8 +21,13 @@ export const tavilySearch = new DynamicStructuredTool({
     query: z.string().describe('The search query to look up on the web'),
   }),
   func: async (input) => {
-    const result = await getTavilyClient().invoke({ query: input.query });
-    const { parsed, urls } = parseSearchResults(result);
-    return formatToolResult(parsed, urls);
+    try {
+      const result = await getTavilyClient().invoke({ query: input.query });
+      const { parsed, urls } = parseSearchResults(result);
+      return formatToolResult(parsed, urls);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Search failed';
+      return formatToolResult({ error: errorMessage }, []);
+    }
   },
 });


### PR DESCRIPTION
## Summary
- Add try/catch around `invoke()` in both `exaSearch` and `tavilySearch` tools
- API/network errors now return `{ error: "message" }` instead of crashing

## Test plan
- [ ] Trigger a search with invalid/missing API key
- [ ] Verify error is returned as data, not thrown
- [ ] Agent can continue after search failure