### PR TITLE
fix: Validate OPENAI_API_KEY in default model factory

### DIFF
--- a/src/model/llm.ts
+++ b/src/model/llm.ts
@@ -90,7 +90,7 @@ const DEFAULT_MODEL_FACTORY: ModelFactory = (name, opts) =>
   new ChatOpenAI({
     model: name,
     ...opts,
-    apiKey: process.env.OPENAI_API_KEY,
+    apiKey: getApiKey('OPENAI_API_KEY', 'OpenAI'),
   });
 
 export function getChatModel(


### PR DESCRIPTION
## Summary
- Use `getApiKey()` for OpenAI model factory, consistent with other providers
- Missing `OPENAI_API_KEY` now throws a clear error instead of silently passing `undefined`

## Test plan
- [ ] Remove `OPENAI_API_KEY` from `.env`
- [ ] Try to run a query with OpenAI model
- [ ] Verify clear error message: "OPENAI_API_KEY not found in environment variables"