### PR TITLE
fix: Guard against undefined pendingModels[0] in model selection

### DIFF
--- a/src/hooks/useModelSelection.ts
+++ b/src/hooks/useModelSelection.ts
@@ -159,8 +159,8 @@ export function useModelSelection(
       setAppState('api_key_input');
     } else {
       // Check if existing key is available
-      if (pendingProvider && checkApiKeyExistsForProvider(pendingProvider)) {
-        const selectedModel = pendingModels[0];
+      const selectedModel = pendingModels[0];
+      if (pendingProvider && selectedModel && checkApiKeyExistsForProvider(pendingProvider)) {
         completeModelSwitch(pendingProvider, selectedModel);
       } else {
         onError(`Cannot use ${pendingProvider ? getProviderDisplayName(pendingProvider) : 'provider'} without an API key.`);
@@ -172,6 +172,13 @@ export function useModelSelection(
   // API key submit handler
   const handleApiKeySubmit = useCallback((apiKey: string | null) => {
     const selectedModel = pendingModels[0];
+    
+    // Guard: ensure we have a selected model
+    if (!selectedModel) {
+      onError('No model selected.');
+      resetPendingState();
+      return;
+    }
     
     if (apiKey && pendingProvider) {
       const saved = saveApiKeyForProvider(pendingProvider, apiKey);


### PR DESCRIPTION
## Summary
- Add null checks before using `pendingModels[0]` in `handleApiKeyConfirm` and `handleApiKeySubmit`
- Prevents passing `undefined` to `completeModelSwitch()` in edge cases

## Test plan
- [ ] Run `/model`, select provider, then cancel before selecting a model
- [ ] Trigger API key flow and verify no crashes on edge cases
- [ ] Verify error messages display correctly when state is incomplete