### PR TITLE
fix: harden JSON parsing, API response handling, and Ollama model list

### DIFF
--- a/src/tools/finance/api.ts
+++ b/src/tools/finance/api.ts
@@ -34,14 +34,11 @@ export async function callApi(
     throw new Error(`API request failed: ${response.status} ${response.statusText}`);
   }
 
-  let data: unknown;
-  try {
-    data = await response.json();
-  } catch {
+  const data = await response.json().catch(() => {
     throw new Error(
       `API request failed: invalid JSON response (${response.status} ${response.statusText})`
     );
-  }
-  return { data: data as Record<string, unknown>, url: url.toString() };
+  });
+  return { data, url: url.toString() };
 }
 

--- a/src/utils/ollama.ts
+++ b/src/utils/ollama.ts
@@ -25,9 +25,10 @@ export async function getOllamaModels(): Promise<string[]> {
       return [];
     }
 
-    const data = (await response.json()) as OllamaTagsResponse | undefined;
-    const models = data?.models ?? [];
-    return models.map((m) => m?.name).filter((n): n is string => typeof n === 'string');
+    const data = (await response.json()) as OllamaTagsResponse;
+    return (data?.models ?? [])
+      .map((m) => m?.name)
+      .filter((n): n is string => typeof n === 'string');
   } catch {
     // Ollama not running or unreachable
     return [];


### PR DESCRIPTION
### Summary

Improves robustness, edge-case handling, and error reporting in three areas:

---

#### 1. **Scratchpad `readEntries()`** (`src/agent/scratchpad.ts`)

- **Problem:** A single malformed or corrupt JSONL line (e.g. crash during write, disk corruption) caused `JSON.parse(line)` to throw and brought down `getToolSummaries()`, `getFullContexts()`, `hasToolResults()`, `hasExecutedSkill()`, and the rest of the agent loop.
- **Change:** Parse line-by-line in try/catch; only keep objects with `type` and `timestamp`. Invalid lines are skipped instead of crashing.

---

#### 2. **Finance API `response.json()`** (`src/tools/finance/api.ts`)

- **Problem:** `response.json()` can throw when the API returns a non-JSON body (HTML error page, proxy/502/503 body, etc.), leading to an opaque `SyntaxError` instead of a clear API failure.
- **Change:** Wrap `response.json()` in try/catch and throw: `API request failed: invalid JSON response (${status} ${statusText})`.

---

#### 3. **Ollama `getOllamaModels()`** (`src/utils/ollama.ts`)

- **Problem:** `data.models` could be missing or not an array (`{}`, `{ models: null }`, or API shape changes), so `data.models.map(...)` could throw. Items without a valid string `name` could also leak into the list.
- **Change:** Use `data?.models ?? []` and filter to valid string names: `.map((m) => m?.name).filter((n): n is string => typeof n === "string")`.

---

Keeps behavior the same for valid inputs; only affects error paths and malformed/unexpected responses.