### PR TITLE
feat: add Kimi K2.5 (Moonshot AI) as LLM provider

### DIFF
--- a/env.example
+++ b/env.example
@@ -4,6 +4,7 @@ ANTHROPIC_API_KEY=your-api-key
 GOOGLE_API_KEY=your-api-key
 XAI_API_KEY=your-api-key
 OPENROUTER_API_KEY=your-api-key
+MOONSHOT_API_KEY=your-api-key
 
 # Ollama (Local LLM)
 OLLAMA_BASE_URL=http://127.0.0.1:11434

--- a/src/components/ModelSelector.tsx
+++ b/src/components/ModelSelector.tsx
@@ -47,6 +47,13 @@ const PROVIDERS: Provider[] = [
     ],
   },
   {
+    displayName: 'Moonshot',
+    providerId: 'moonshot',
+    models: [
+      { id: 'kimi-k2-5', displayName: 'Kimi K2.5' },
+    ],
+  },
+  {
     displayName: 'OpenRouter',
     providerId: 'openrouter',
     models: [], // User types model name directly

--- a/src/model/llm.ts
+++ b/src/model/llm.ts
@@ -22,6 +22,7 @@ const FAST_MODELS: Record<string, string> = {
   google: 'gemini-3-flash-preview',
   xai: 'grok-4-1-fast-reasoning',
   openrouter: 'openrouter:openai/gpt-4o-mini',
+  moonshot: 'kimi-k2-5',
 };
 
 /**
@@ -89,6 +90,15 @@ const MODEL_PROVIDERS: Record<string, ModelFactory> = {
       apiKey: getApiKey('OPENROUTER_API_KEY', 'OpenRouter'),
       configuration: {
         baseURL: 'https://openrouter.ai/api/v1',
+      },
+    }),
+  'kimi-': (name, opts) =>
+    new ChatOpenAI({
+      model: name,
+      ...opts,
+      apiKey: getApiKey('MOONSHOT_API_KEY', 'Moonshot'),
+      configuration: {
+        baseURL: 'https://api.moonshot.cn/v1',
       },
     }),
   'ollama:': (name, opts) =>

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -14,6 +14,7 @@ const PROVIDERS: Record<string, ProviderConfig> = {
   openai: { displayName: 'OpenAI', apiKeyEnvVar: 'OPENAI_API_KEY' },
   anthropic: { displayName: 'Anthropic', apiKeyEnvVar: 'ANTHROPIC_API_KEY' },
   google: { displayName: 'Google', apiKeyEnvVar: 'GOOGLE_API_KEY' },
+  moonshot: { displayName: 'Moonshot', apiKeyEnvVar: 'MOONSHOT_API_KEY' },
   openrouter: { displayName: 'OpenRouter', apiKeyEnvVar: 'OPENROUTER_API_KEY' },
   ollama: { displayName: 'Ollama' },
 };


### PR DESCRIPTION
## Summary
- Adds **Moonshot AI** as a new LLM provider with their **Kimi K2.5** model
- Kimi's API is OpenAI-compatible, so the integration uses `ChatOpenAI` with a custom base URL (`https://api.moonshot.cn/v1`) — same pattern as xAI/Grok
- Kimi K2.5 excels at long-context understanding (up to 2M tokens), financial analysis, and coding tasks

## Changes
- **`src/model/llm.ts`** — Added `kimi-` prefix model factory and `moonshot` fast model variant
- **`src/utils/env.ts`** — Registered Moonshot provider config with `MOONSHOT_API_KEY`
- **`src/components/ModelSelector.tsx`** — Added Moonshot provider with Kimi K2.5 model to the UI
- **`env.example`** — Added `MOONSHOT_API_KEY` placeholder

## Test plan
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] All existing tests pass (`bun test` — 9/9)
- [ ] Manual testing with a Moonshot API key (requires account at https://platform.moonshot.cn/)

Closes #105