### PR TITLE
feat: Add Forge LLM provider support

### DIFF
--- a/env.example
+++ b/env.example
@@ -4,6 +4,7 @@ ANTHROPIC_API_KEY=your-api-key
 GOOGLE_API_KEY=your-api-key
 XAI_API_KEY=your-api-key
 OPENROUTER_API_KEY=your-api-key
+FORGE_API_KEY=your-api-key
 
 # Ollama (Local LLM)
 OLLAMA_BASE_URL=http://127.0.0.1:11434

--- a/src/model/llm.ts
+++ b/src/model/llm.ts
@@ -22,6 +22,7 @@ const FAST_MODELS: Record<string, string> = {
   google: 'gemini-3-flash-preview',
   xai: 'grok-4-1-fast-reasoning',
   openrouter: 'openrouter:openai/gpt-4o-mini',
+  forge: 'forge:OpenAI/gpt-4o-mini',
 };
 
 /**
@@ -89,6 +90,15 @@ const MODEL_PROVIDERS: Record<string, ModelFactory> = {
       apiKey: getApiKey('OPENROUTER_API_KEY', 'OpenRouter'),
       configuration: {
         baseURL: 'https://openrouter.ai/api/v1',
+      },
+    }),
+  'forge:': (name, opts) =>
+    new ChatOpenAI({
+      model: name.replace(/^forge:/, ''),
+      ...opts,
+      apiKey: getApiKey('FORGE_API_KEY', 'Forge'),
+      configuration: {
+        baseURL: 'https://api.forge.tensorblock.co/v1',
       },
     }),
   'ollama:': (name, opts) =>

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -15,6 +15,7 @@ const PROVIDERS: Record<string, ProviderConfig> = {
   anthropic: { displayName: 'Anthropic', apiKeyEnvVar: 'ANTHROPIC_API_KEY' },
   google: { displayName: 'Google', apiKeyEnvVar: 'GOOGLE_API_KEY' },
   openrouter: { displayName: 'OpenRouter', apiKeyEnvVar: 'OPENROUTER_API_KEY' },
+  forge: { displayName: 'Forge', apiKeyEnvVar: 'FORGE_API_KEY' },
   ollama: { displayName: 'Ollama' },
 };
 


### PR DESCRIPTION
Adds support for Forge LLM provider.

**Related Issues:**
- Addresses #103 - Users can access Azure OpenAI through Forge router
- Addresses #105 - Users can access Kimi K2.5 through Forge router (if configured in Forge)

**Changes:**
- Model format: `forge:Provider/model-name` (e.g., `forge:OpenAI/gpt-4o-mini`)
- Environment variable: `FORGE_API_KEY`
- Base URL: `https://api.forge.tensorblock.co/v1`
- Fast model: `forge:OpenAI/gpt-4o-mini`

**Implementation:**
- 3 files modified: `src/model/llm.ts`, `src/utils/env.ts`, `env.example`
- TypeScript type check passed

**Note:** 
Forge is an LLM router that provides unified access to multiple providers. Users can access Azure OpenAI (#103) and Kimi K2.5 (#105) through Forge if they have configured these providers in their Forge account.

**Testing:**
- Existing tests pass (cache functionality, unrelated to LLM providers)
- CI will verify with Bun test runner