### PR TITLE
feat: add DeepSeek as LLM provider

### DIFF
--- a/env.example
+++ b/env.example
@@ -5,6 +5,7 @@ GOOGLE_API_KEY=your-api-key
 XAI_API_KEY=your-api-key
 OPENROUTER_API_KEY=your-api-key
 MOONSHOT_API_KEY=your-api-key
+DEEPSEEK_API_KEY=your-api-key
 
 # Ollama (Local LLM)
 OLLAMA_BASE_URL=http://127.0.0.1:11434

--- a/src/components/ModelSelector.tsx
+++ b/src/components/ModelSelector.tsx
@@ -54,6 +54,14 @@ const PROVIDERS: Provider[] = [
     ],
   },
   {
+    displayName: 'DeepSeek',
+    providerId: 'deepseek',
+    models: [
+      { id: 'deepseek-chat', displayName: 'DeepSeek V3' },
+      { id: 'deepseek-reasoner', displayName: 'DeepSeek R1' },
+    ],
+  },
+  {
     displayName: 'OpenRouter',
     providerId: 'openrouter',
     models: [], // User types model name directly

--- a/src/model/llm.ts
+++ b/src/model/llm.ts
@@ -23,6 +23,7 @@ const FAST_MODELS: Record<string, string> = {
   xai: 'grok-4-1-fast-reasoning',
   openrouter: 'openrouter:openai/gpt-4o-mini',
   moonshot: 'kimi-k2-5',
+  deepseek: 'deepseek-chat',
 };
 
 /**
@@ -99,6 +100,15 @@ const MODEL_PROVIDERS: Record<string, ModelFactory> = {
       apiKey: getApiKey('MOONSHOT_API_KEY', 'Moonshot'),
       configuration: {
         baseURL: 'https://api.moonshot.cn/v1',
+      },
+    }),
+  'deepseek-': (name, opts) =>
+    new ChatOpenAI({
+      model: name,
+      ...opts,
+      apiKey: getApiKey('DEEPSEEK_API_KEY', 'DeepSeek'),
+      configuration: {
+        baseURL: 'https://api.deepseek.com',
       },
     }),
   'ollama:': (name, opts) =>

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -15,6 +15,7 @@ const PROVIDERS: Record<string, ProviderConfig> = {
   anthropic: { displayName: 'Anthropic', apiKeyEnvVar: 'ANTHROPIC_API_KEY' },
   google: { displayName: 'Google', apiKeyEnvVar: 'GOOGLE_API_KEY' },
   moonshot: { displayName: 'Moonshot', apiKeyEnvVar: 'MOONSHOT_API_KEY' },
+  deepseek: { displayName: 'DeepSeek', apiKeyEnvVar: 'DEEPSEEK_API_KEY' },
   openrouter: { displayName: 'OpenRouter', apiKeyEnvVar: 'OPENROUTER_API_KEY' },
   ollama: { displayName: 'Ollama' },
 };


### PR DESCRIPTION
## Summary
- Adds **DeepSeek AI** as a new LLM provider with **DeepSeek V3** (`deepseek-chat`) and **DeepSeek R1** (`deepseek-reasoner`) models
- DeepSeek's API is OpenAI-compatible, so the integration uses `ChatOpenAI` with a custom base URL (`https://api.deepseek.com`) — same pattern as xAI/Grok and Moonshot/Kimi
- Users just need to set `DEEPSEEK_API_KEY` and select DeepSeek from the provider list

## Changes
- **`src/model/llm.ts`** — Added `deepseek-` prefix model factory and `deepseek` fast model variant
- **`src/utils/env.ts`** — Registered DeepSeek provider config with `DEEPSEEK_API_KEY`
- **`src/components/ModelSelector.tsx`** — Added DeepSeek provider with V3 and R1 models to the UI
- **`env.example`** — Added `DEEPSEEK_API_KEY` placeholder

## Test plan
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] All existing tests pass (`bun test` — 9/9)
- [ ] Manual testing with a DeepSeek API key (requires account at https://platform.deepseek.com/)

Closes #111