### PR TITLE
Fix terminal display flickering on macOS

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -223,8 +223,8 @@ export function CLI() {
         />
       </Box>
       
-      {/* Debug Panel - set show={false} to hide */}
-      <DebugPanel maxLines={8} show={true} />
+      {/* Debug Panel - set show={true} to enable */}
+      <DebugPanel maxLines={8} show={false} />
     </Box>
   );
 }

--- a/src/components/WorkingIndicator.tsx
+++ b/src/components/WorkingIndicator.tsx
@@ -1,57 +1,8 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Box, Text } from 'ink';
 import Spinner from 'ink-spinner';
 import { colors } from '../theme.js';
 import { getRandomThinkingVerb } from '../utils/thinking-verbs.js';
-
-/**
- * Renders text with a shine effect that sweeps left-to-right
- */
-function ShineText({ text, color, shineColor }: { text: string; color: string; shineColor: string }) {
-  const [shinePos, setShinePos] = useState(0);
-  const [isPaused, setIsPaused] = useState(false);
-  
-  useEffect(() => {
-    if (isPaused) {
-      // Wait 2 seconds before restarting the shine
-      const timeout = setTimeout(() => {
-        setShinePos(0);
-        setIsPaused(false);
-      }, 2000);
-      return () => clearTimeout(timeout);
-    }
-    
-    const interval = setInterval(() => {
-      setShinePos((prev) => {
-        const next = prev + 1;
-        if (next >= text.length) {
-          setIsPaused(true);
-          return prev; // Keep at end position until pause completes
-        }
-        return next;
-      });
-    }, 30);
-    
-    return () => clearInterval(interval);
-  }, [isPaused, text.length]);
-  
-  // Memoize the rendered parts for performance
-  const parts = useMemo(() => {
-    const result: React.ReactNode[] = [];
-    for (let i = 0; i < text.length; i++) {
-      // Highlight characters within 1.25 of shine position (~2.5 char width)
-      const isShine = !isPaused && Math.abs(i - shinePos) < 1.25;
-      result.push(
-        <Text key={i} color={isShine ? shineColor : color}>
-          {text[i]}
-        </Text>
-      );
-    }
-    return result;
-  }, [text, shinePos, isPaused, color, shineColor]);
-  
-  return <>{parts}</>;
-}
 
 export type WorkingState = 
   | { status: 'idle' }
@@ -124,7 +75,7 @@ export function WorkingIndicator({ state }: WorkingIndicatorProps) {
         <Spinner type="dots" />
       </Text>
       <Text color={colors.primary}> </Text>
-      <ShineText text={statusWord} color={colors.primary} shineColor={colors.primaryLight} />
+      <Text color={colors.primary}>{statusWord}</Text>
       <Text color={colors.muted}> (</Text>
       <Text color={colors.muted} bold>esc</Text>
       <Text color={colors.muted}>{suffixEnd}</Text>


### PR DESCRIPTION
## Summary

- **Remove `ShineText` per-character animation** in `WorkingIndicator.tsx` — it runs a 30ms `setInterval` that triggers ~33 full Ink re-renders/second, causing visible screen flickering and jumping. Replaced with static colored `<Text>`. The `Spinner` component still provides a working indicator animation.
- **Default `DebugPanel` to `show={false}`** in `cli.tsx` — it was enabled by default and re-renders on every log entry during agent execution, causing layout height changes that compound the flickering.

## Reproduction

Observed on a clean macOS install (Darwin 24.3.0) running `bun start`. During agent execution the terminal output shimmers and jumps. The root cause is three overlapping animation timers (ShineText 30ms interval + Spinner + DebugPanel log subscription) each triggering full Ink redraws.

## Test plan

- [ ] Run `bun start` and submit a query — display should be stable during thinking/tool execution
- [ ] Verify `Spinner` dots animation still appears in the working indicator
- [ ] Confirm `bun run typecheck` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)