### PR TITLE
Add eval reliability checks and regression coverage

### DIFF
--- a/src/evals/core.test.ts
+++ b/src/evals/core.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect } from 'bun:test';
+import { parseCSV, parseRow, runReliabilityChecks } from './core.js';
+
+describe('parseRow', () => {
+  test('returns null for blank lines', () => {
+    const lines = ['Question,Answer', '', 'Q1,A1'];
+    expect(parseRow(lines, 1)).toBeNull();
+  });
+
+  test('parses quoted fields with escaped quotes', () => {
+    const lines = ['Question,Answer', '"What is ""beta""?","A volatility measure"'];
+    const row = parseRow(lines, 1);
+    expect(row).not.toBeNull();
+    expect(row!.row[0]).toBe('What is "beta"?');
+    expect(row!.row[1]).toBe('A volatility measure');
+  });
+});
+
+describe('parseCSV', () => {
+  test('parses multiline quoted answers', () => {
+    const csv = [
+      'Question,Answer',
+      '"Give me two lines","Line one',
+      'Line two"',
+      'Q2,A2',
+    ].join('\n');
+
+    const examples = parseCSV(csv);
+    expect(examples).toHaveLength(2);
+    expect(examples[0].inputs.question).toBe('Give me two lines');
+    expect(examples[0].outputs.answer).toBe('Line one\nLine two');
+    expect(examples[1].inputs.question).toBe('Q2');
+    expect(examples[1].outputs.answer).toBe('A2');
+  });
+});
+
+describe('runReliabilityChecks', () => {
+  test('fails empty answers', () => {
+    const result = runReliabilityChecks('   ');
+    expect(result.passed).toBe(false);
+    expect(result.issues.some((i) => i.code === 'empty_answer')).toBe(true);
+  });
+
+  test('fails on internal payload leaks', () => {
+    const result = runReliabilityChecks('{"data":{},"sourceUrls":["https://example.com"]}');
+    expect(result.passed).toBe(false);
+    expect(result.issues.some((i) => i.code === 'internal_sourceurls_leak')).toBe(true);
+    expect(result.issues.some((i) => i.code === 'raw_payload_output')).toBe(true);
+  });
+
+  test('fails on explicit upstream errors', () => {
+    const result = runReliabilityChecks('API request failed: 429 Too Many Requests');
+    expect(result.passed).toBe(false);
+    expect(result.issues.some((i) => i.code === 'api_request_failed')).toBe(true);
+  });
+
+  test('passes clean user-facing answers', () => {
+    const result = runReliabilityChecks(
+      'Airbnb CFO is Ellie Mertz based on the most recent company filings.'
+    );
+    expect(result.passed).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+});
+

--- a/src/evals/core.ts
+++ b/src/evals/core.ts
@@ -1,0 +1,214 @@
+/**
+ * Shared eval helpers used by the eval runner and unit tests.
+ */
+
+// Types
+export interface EvalExample {
+  inputs: { question: string };
+  outputs: { answer: string };
+}
+
+export interface ReliabilityIssue {
+  code: string;
+  message: string;
+}
+
+export interface ReliabilityCheckResult {
+  passed: boolean;
+  issues: ReliabilityIssue[];
+}
+
+/**
+ * Parse CSV content into eval examples.
+ * Handles quoted commas, escaped quotes, and multi-line fields.
+ */
+export function parseCSV(csvContent: string): EvalExample[] {
+  const examples: EvalExample[] = [];
+  const lines = csvContent.split('\n');
+
+  let i = 1; // Skip header row
+
+  while (i < lines.length) {
+    const result = parseRow(lines, i);
+    if (result) {
+      const { row, nextIndex } = result;
+      if (row.length >= 2 && row[0].trim()) {
+        examples.push({
+          inputs: { question: row[0] },
+          outputs: { answer: row[1] },
+        });
+      }
+      i = nextIndex;
+    } else {
+      i++;
+    }
+  }
+
+  return examples;
+}
+
+/**
+ * Parse a single CSV row from the given line index.
+ * Returns null for blank lines.
+ */
+export function parseRow(
+  lines: string[],
+  startIndex: number
+): { row: string[]; nextIndex: number } | null {
+  if (startIndex >= lines.length || !lines[startIndex].trim()) {
+    return null;
+  }
+
+  const fields: string[] = [];
+  let currentField = '';
+  let inQuotes = false;
+  let lineIndex = startIndex;
+  let charIndex = 0;
+
+  while (lineIndex < lines.length) {
+    const line = lines[lineIndex];
+
+    while (charIndex < line.length) {
+      const char = line[charIndex];
+      const nextChar = line[charIndex + 1];
+
+      if (inQuotes) {
+        if (char === '"' && nextChar === '"') {
+          // Escaped quote
+          currentField += '"';
+          charIndex += 2;
+        } else if (char === '"') {
+          // End of quoted field
+          inQuotes = false;
+          charIndex++;
+        } else {
+          currentField += char;
+          charIndex++;
+        }
+      } else if (char === ',') {
+        // End of field
+        fields.push(currentField);
+        currentField = '';
+        charIndex++;
+      } else if (char === '"') {
+        // Start of quoted field
+        inQuotes = true;
+        charIndex++;
+      } else {
+        currentField += char;
+        charIndex++;
+      }
+    }
+
+    if (inQuotes) {
+      // Continue to next line (multi-line field)
+      currentField += '\n';
+      lineIndex++;
+      charIndex = 0;
+    } else {
+      // Row complete
+      fields.push(currentField);
+      return { row: fields, nextIndex: lineIndex + 1 };
+    }
+  }
+
+  // Handle case where file ends while in quotes
+  if (currentField) {
+    fields.push(currentField);
+  }
+  return { row: fields, nextIndex: lineIndex };
+}
+
+/**
+ * Deterministic sanity checks for generated answers.
+ * These checks are strict on clear failure modes (errors, internal payload leaks)
+ * and are used as a reliability gate in eval scoring.
+ */
+export function runReliabilityChecks(answer: string): ReliabilityCheckResult {
+  const issues: ReliabilityIssue[] = [];
+  const trimmed = answer.trim();
+
+  if (!trimmed) {
+    issues.push({
+      code: 'empty_answer',
+      message: 'Generated answer is empty.',
+    });
+    return { passed: false, issues };
+  }
+
+  if (trimmed.length > 20_000) {
+    issues.push({
+      code: 'oversized_answer',
+      message: 'Generated answer exceeds 20,000 characters.',
+    });
+  }
+
+  const internalLeakPatterns: Array<{ pattern: RegExp; code: string; message: string }> = [
+    {
+      pattern: /\bsourceUrls?\b/i,
+      code: 'internal_sourceurls_leak',
+      message: 'Answer leaked internal `sourceUrls` payload field.',
+    },
+    {
+      pattern: /\btool_calls?\b/i,
+      code: 'internal_tool_calls_leak',
+      message: 'Answer leaked internal tool call payload.',
+    },
+    {
+      pattern: /\bfinancialdatasets\.ai\b/i,
+      code: 'internal_api_url_leak',
+      message: 'Answer leaked raw Financial Datasets API URL.',
+    },
+  ];
+
+  for (const { pattern, code, message } of internalLeakPatterns) {
+    if (pattern.test(trimmed)) {
+      issues.push({ code, message });
+    }
+  }
+
+  const failurePatterns: Array<{ pattern: RegExp; code: string; message: string }> = [
+    {
+      pattern: /\bno tools available\b/i,
+      code: 'tool_unavailable',
+      message: 'Answer contains tool availability failure.',
+    },
+    {
+      pattern: /\bapi request failed\b/i,
+      code: 'api_request_failed',
+      message: 'Answer contains upstream API failure text.',
+    },
+    {
+      pattern: /\bfailed to (parse|select|fetch)\b/i,
+      code: 'tool_parse_or_fetch_failure',
+      message: 'Answer contains tool parsing/fetch failure text.',
+    },
+  ];
+
+  for (const { pattern, code, message } of failurePatterns) {
+    if (pattern.test(trimmed)) {
+      issues.push({ code, message });
+    }
+  }
+
+  const looksLikeRawToolPayload =
+    (/^\s*\{[\s\S]*\}\s*$/.test(trimmed) || /^\s*\[[\s\S]*\]\s*$/.test(trimmed)) &&
+    (/"data"\s*:/.test(trimmed) || /"sourceUrls"\s*:/.test(trimmed));
+
+  if (looksLikeRawToolPayload) {
+    issues.push({
+      code: 'raw_payload_output',
+      message: 'Answer appears to be raw tool JSON instead of a user-facing response.',
+    });
+  }
+
+  return {
+    passed: issues.length === 0,
+    issues,
+  };
+}
+
+export function formatReliabilityIssues(issues: ReliabilityIssue[]): string {
+  return issues.map((i) => i.message).join(' ');
+}
+

--- a/src/evals/dataset/finance_agent_regression.csv
+++ b/src/evals/dataset/finance_agent_regression.csv
@@ -1,0 +1,14 @@
+Question,Answer
+Who is the current CFO of Airbnb (NASDAQ: ABNB)?,Ellie Mertz
+What was FND same-store sales growth in Q4 2024?,-0.8%
+How many basis points did MU beat or miss its Q3 2024 GAAP gross margin guidance?,140bps BEAT
+Did FOUR beat or miss its end to end payment volume guidance at midpoint for Q3 2024 provided in Q1 2024? Express as percent BEAT or MISS,7.4% MISS
+What is the maximum dilutive impact in number of shares of Snapchat's outstanding convertible notes as of 12/31/2024?,"85,945,127 shares if all converts were converted"
+As of Dec 31 2024 what was Warner Bros. Discovery total restructuring costs incurred as a result of its 2022 merger?,$4.7 Billion
+In fiscal 2024 what percentage of Cloudflare's revenue were derived from channel partners?,20%
+What was the total consideration cost TKO paid to acquired Endeavor assets measured at transaction close?,$3.25 Billion
+In 2024 what was Airbnb's adjustment for stock-based compensation expense?,"$1,407,000,000"
+For loanDepot NYSE LDI what is the breakdown of loan originations between purchases and refinancings for the last 9 months as of 11/12/2024?,"Purchase: $12,057,993; Refinance: $5,250,321; in thousands"
+Did TJX beat or miss its Q4 FY 2025 pre-tax margin guidance?,"80bps beat from low end and 70bps beat from high end"
+Of AMZN META or GOOG who plans to spend the most in capex in 2025?,AMZN
+How did Lyft's Q4 2024 adjusted EBITDA margin compare to management guidance midpoint from Q3 2024?,"Beat by 26.1bps at midpoint"

--- a/src/evals/run.ts
+++ b/src/evals/run.ts
@@ -2,8 +2,14 @@
  * LangSmith Evaluation Runner for Dexter
  * 
  * Usage:
- *   bun run src/evals/run.ts              # Run on all questions
- *   bun run src/evals/run.ts --sample 10  # Run on random sample of 10 questions
+ *   bun run src/evals/run.ts                             # Run full default dataset
+ *   bun run src/evals/run.ts --sample 10                 # Run random sample
+ *   bun run src/evals/run.ts --dataset regression        # Run regression dataset
+ *   bun run src/evals/run.ts --dataset ./path/to.csv     # Run custom CSV
+ *
+ * Reliability gate:
+ *   Generated answers must pass deterministic reliability checks
+ *   (no empty responses, tool failure text, raw tool payload leaks).
  */
 
 import 'dotenv/config';
@@ -18,110 +24,15 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { Agent } from '../agent/agent.js';
 import { EvalApp, type EvalProgressEvent } from './components/index.js';
+import { parseCSV, runReliabilityChecks, formatReliabilityIssues } from './core.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Types
-interface Example {
-  inputs: { question: string };
-  outputs: { answer: string };
-}
-
-// ============================================================================
-// CSV Parser - handles multi-line quoted fields
-// ============================================================================
-
-function parseCSV(csvContent: string): Example[] {
-  const examples: Example[] = [];
-  const lines = csvContent.split('\n');
-  
-  let i = 1; // Skip header row
-  
-  while (i < lines.length) {
-    const result = parseRow(lines, i);
-    if (result) {
-      const { row, nextIndex } = result;
-      if (row.length >= 2 && row[0].trim()) {
-        examples.push({
-          inputs: { question: row[0] },
-          outputs: { answer: row[1] }
-        });
-      }
-      i = nextIndex;
-    } else {
-      i++;
-    }
-  }
-  
-  return examples;
-}
-
-function parseRow(lines: string[], startIndex: number): { row: string[]; nextIndex: number } | null {
-  if (startIndex >= lines.length || !lines[startIndex].trim()) {
-    return null;
-  }
-  
-  const fields: string[] = [];
-  let currentField = '';
-  let inQuotes = false;
-  let lineIndex = startIndex;
-  let charIndex = 0;
-  
-  while (lineIndex < lines.length) {
-    const line = lines[lineIndex];
-    
-    while (charIndex < line.length) {
-      const char = line[charIndex];
-      const nextChar = line[charIndex + 1];
-      
-      if (inQuotes) {
-        if (char === '"' && nextChar === '"') {
-          // Escaped quote
-          currentField += '"';
-          charIndex += 2;
-        } else if (char === '"') {
-          // End of quoted field
-          inQuotes = false;
-          charIndex++;
-        } else {
-          currentField += char;
-          charIndex++;
-        }
-      } else {
-        if (char === '"') {
-          // Start of quoted field
-          inQuotes = true;
-          charIndex++;
-        } else if (char === ',') {
-          // End of field
-          fields.push(currentField);
-          currentField = '';
-          charIndex++;
-        } else {
-          currentField += char;
-          charIndex++;
-        }
-      }
-    }
-    
-    if (inQuotes) {
-      // Continue to next line (multi-line field)
-      currentField += '\n';
-      lineIndex++;
-      charIndex = 0;
-    } else {
-      // Row complete
-      fields.push(currentField);
-      return { row: fields, nextIndex: lineIndex + 1 };
-    }
-  }
-  
-  // Handle case where file ends while in quotes
-  if (currentField) {
-    fields.push(currentField);
-  }
-  return { row: fields, nextIndex: lineIndex };
+interface DatasetConfig {
+  datasetPath: string;
+  datasetLabel: string;
 }
 
 // ============================================================================
@@ -152,6 +63,64 @@ async function target(inputs: { question: string }): Promise<{ answer: string }>
   }
   
   return { answer };
+}
+
+// ============================================================================
+// CLI arg helpers
+// ============================================================================
+
+function getArgValue(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  if (idx === -1 || idx === args.length - 1) {
+    return undefined;
+  }
+  return args[idx + 1];
+}
+
+function parseSampleSize(args: string[]): number | undefined {
+  const raw = getArgValue(args, '--sample');
+  if (!raw) return undefined;
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid --sample value: ${raw}`);
+  }
+  return parsed;
+}
+
+function resolveDatasetConfig(args: string[]): DatasetConfig {
+  const raw = getArgValue(args, '--dataset');
+  const datasetArg = raw?.trim() || 'finance_agent';
+  const datasetDir = path.join(__dirname, 'dataset');
+
+  if (datasetArg === 'finance_agent') {
+    return {
+      datasetPath: path.join(datasetDir, 'finance_agent.csv'),
+      datasetLabel: 'finance_agent',
+    };
+  }
+
+  if (datasetArg === 'regression' || datasetArg === 'finance_agent_regression') {
+    return {
+      datasetPath: path.join(datasetDir, 'finance_agent_regression.csv'),
+      datasetLabel: 'finance_agent_regression',
+    };
+  }
+
+  const isPathLike = datasetArg.endsWith('.csv') || datasetArg.includes('/') || datasetArg.includes('\\');
+  if (isPathLike) {
+    const resolved = path.isAbsolute(datasetArg)
+      ? datasetArg
+      : path.resolve(process.cwd(), datasetArg);
+    return {
+      datasetPath: resolved,
+      datasetLabel: path.basename(resolved, '.csv') || 'custom_dataset',
+    };
+  }
+
+  throw new Error(
+    `Unknown dataset "${datasetArg}". Use finance_agent, regression, or a CSV file path.`
+  );
 }
 
 // ============================================================================
@@ -215,12 +184,16 @@ Evaluate and provide:
 // Evaluation generator - yields progress events for the UI
 // ============================================================================
 
-function createEvaluationRunner(sampleSize?: number) {
+function createEvaluationRunner(sampleSize: number | undefined, dataset: DatasetConfig) {
   return async function* runEvaluation(): AsyncGenerator<EvalProgressEvent, void, unknown> {
     // Load and parse dataset
-    const csvPath = path.join(__dirname, 'dataset', 'finance_agent.csv');
-    const csvContent = fs.readFileSync(csvPath, 'utf-8');
+    const csvContent = fs.readFileSync(dataset.datasetPath, 'utf-8');
     let examples = parseCSV(csvContent);
+
+    if (examples.length === 0) {
+      throw new Error(`Dataset has no examples: ${dataset.datasetPath}`);
+    }
+
     const totalCount = examples.length;
 
     // Apply sampling if requested
@@ -233,30 +206,32 @@ function createEvaluationRunner(sampleSize?: number) {
 
     // Create a unique dataset name for this run (sampling creates different datasets)
     const datasetName = sampleSize 
-      ? `dexter-finance-eval-sample-${sampleSize}-${Date.now()}`
-      : 'dexter-finance-eval';
+      ? `dexter-${dataset.datasetLabel}-sample-${sampleSize}-${Date.now()}`
+      : `dexter-${dataset.datasetLabel}`;
 
     // Yield init event
     yield {
       type: 'init',
       total: examples.length,
-      datasetName: sampleSize ? `finance_agent (sample ${sampleSize}/${totalCount})` : 'finance_agent',
+      datasetName: sampleSize
+        ? `${dataset.datasetLabel} (sample ${sampleSize}/${totalCount})`
+        : dataset.datasetLabel,
     };
 
     // Check if dataset exists (only for full runs)
-    let dataset;
+    let langsmithDataset;
     if (!sampleSize) {
       try {
-        dataset = await client.readDataset({ datasetName });
+        langsmithDataset = await client.readDataset({ datasetName });
       } catch {
         // Dataset doesn't exist, will create
-        dataset = null;
+        langsmithDataset = null;
       }
     }
 
     // Create dataset if needed
-    if (!dataset) {
-      dataset = await client.createDataset(datasetName, {
+    if (!langsmithDataset) {
+      langsmithDataset = await client.createDataset(datasetName, {
         description: sampleSize 
           ? `Finance agent evaluation (sample of ${sampleSize})`
           : 'Finance agent evaluation dataset',
@@ -264,7 +239,7 @@ function createEvaluationRunner(sampleSize?: number) {
 
       // Upload examples
       await client.createExamples({
-        datasetId: dataset.id,
+        datasetId: langsmithDataset.id,
         inputs: examples.map((e) => e.inputs),
         outputs: examples.map((e) => e.outputs),
       });
@@ -288,12 +263,24 @@ function createEvaluationRunner(sampleSize?: number) {
       const outputs = await target(example.inputs);
       const endTime = Date.now();
 
-      // Run the correctness evaluator
-      const evalResult = await correctnessEvaluator({
-        inputs: example.inputs,
-        outputs,
-        referenceOutputs: example.outputs,
-      });
+      // Run reliability checks first; skip judge call on obvious failures
+      const reliability = runReliabilityChecks(outputs.answer);
+
+      let evalResult: EvaluationResult;
+      if (!reliability.passed) {
+        evalResult = {
+          key: 'correctness',
+          score: 0,
+          comment: `Reliability check failed. ${formatReliabilityIssues(reliability.issues)}`,
+        };
+      } else {
+        // Run the correctness evaluator
+        evalResult = await correctnessEvaluator({
+          inputs: example.inputs,
+          outputs,
+          referenceOutputs: example.outputs,
+        });
+      }
 
       // Log to LangSmith for tracking
       await client.createRun({
@@ -310,6 +297,10 @@ function createEvaluationRunner(sampleSize?: number) {
           evaluation: {
             score: evalResult.score,
             comment: evalResult.comment,
+            reliability: {
+              passed: reliability.passed,
+              issues: reliability.issues,
+            },
           },
         },
       });
@@ -338,11 +329,11 @@ function createEvaluationRunner(sampleSize?: number) {
 async function main() {
   // Parse CLI arguments
   const args = process.argv.slice(2);
-  const sampleIndex = args.indexOf('--sample');
-  const sampleSize = sampleIndex !== -1 ? parseInt(args[sampleIndex + 1]) : undefined;
+  const sampleSize = parseSampleSize(args);
+  const dataset = resolveDatasetConfig(args);
 
-  // Create the evaluation runner with the sample size
-  const runEvaluation = createEvaluationRunner(sampleSize);
+  // Create the evaluation runner with selected options
+  const runEvaluation = createEvaluationRunner(sampleSize, dataset);
 
   // Render the Ink UI
   const { waitUntilExit } = render(
@@ -352,4 +343,7 @@ async function main() {
   await waitUntilExit();
 }
 
-main().catch(console.error);
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/utils/env.test.ts
+++ b/src/utils/env.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from 'bun:test';
+import { getApiKeyNameForProvider, getProviderDisplayName } from './env.js';
+
+describe('provider api key mapping', () => {
+  test('includes all cloud providers used by model selection', () => {
+    const requiredCloudProviders = [
+      'openai',
+      'anthropic',
+      'google',
+      'xai',
+      'moonshot',
+      'deepseek',
+      'openrouter',
+    ] as const;
+
+    for (const provider of requiredCloudProviders) {
+      const envVar = getApiKeyNameForProvider(provider);
+      if (!envVar) {
+        throw new Error(`missing api key mapping for provider: ${provider}`);
+      }
+    }
+  });
+
+  test('xai provider maps to XAI_API_KEY', () => {
+    expect(getProviderDisplayName('xai')).toBe('xAI');
+    expect(getApiKeyNameForProvider('xai')).toBe('XAI_API_KEY');
+  });
+});

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -14,6 +14,7 @@ const PROVIDERS: Record<string, ProviderConfig> = {
   openai: { displayName: 'OpenAI', apiKeyEnvVar: 'OPENAI_API_KEY' },
   anthropic: { displayName: 'Anthropic', apiKeyEnvVar: 'ANTHROPIC_API_KEY' },
   google: { displayName: 'Google', apiKeyEnvVar: 'GOOGLE_API_KEY' },
+  xai: { displayName: 'xAI', apiKeyEnvVar: 'XAI_API_KEY' },
   moonshot: { displayName: 'Moonshot', apiKeyEnvVar: 'MOONSHOT_API_KEY' },
   deepseek: { displayName: 'DeepSeek', apiKeyEnvVar: 'DEEPSEEK_API_KEY' },
   openrouter: { displayName: 'OpenRouter', apiKeyEnvVar: 'OPENROUTER_API_KEY' },

--- a/src/utils/progress-channel.test.ts
+++ b/src/utils/progress-channel.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from 'bun:test';
+import { createProgressChannel } from './progress-channel.js';
+
+describe('createProgressChannel', () => {
+  test('drains buffered messages in order', async () => {
+    const channel = createProgressChannel();
+    channel.emit('Searching...');
+    channel.emit('Fetching filings...');
+    channel.close();
+
+    const received: string[] = [];
+    for await (const msg of channel) {
+      received.push(msg);
+    }
+
+    expect(received).toEqual(['Searching...', 'Fetching filings...']);
+  });
+
+  test('delivers messages to a waiting consumer', async () => {
+    const channel = createProgressChannel();
+    const iterator = channel[Symbol.asyncIterator]();
+
+    const nextPromise = iterator.next();
+    queueMicrotask(() => channel.emit('Running tool...'));
+
+    const first = await nextPromise;
+    expect(first.done).toBe(false);
+    expect(first.value).toBe('Running tool...');
+
+    channel.close();
+    const end = await iterator.next();
+    expect(end.done).toBe(true);
+  });
+
+  test('close unblocks pending next with done=true', async () => {
+    const channel = createProgressChannel();
+    const iterator = channel[Symbol.asyncIterator]();
+
+    const pending = iterator.next();
+    channel.close();
+
+    const result = await pending;
+    expect(result.done).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary\n- extract eval parsing/reliability logic into a shared core module\n- add deterministic reliability gates before LLM judging in eval runs\n- add dataset selection support for eval runs (default, regression, custom CSV)\n- add focused regression eval dataset\n- add regression tests for env provider key mapping and progress channel behavior\n- add eval core unit tests for CSV parsing + reliability checks\n- include xAI provider API-key mapping fix in env config\n\n## Validation\n- bun run typecheck\n- bun test