### PR TITLE
feat: add terminal chart visualization for financial data

### DIFF
--- a/src/utils/charts.test.ts
+++ b/src/utils/charts.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  formatCompactNumber,
+  parseNumericValue,
+  detectChartOpportunity,
+  renderBarChart,
+  renderSparkline,
+  transformChartsInResponse,
+} from './charts.js';
+
+describe('formatCompactNumber', () => {
+  test('formats billions', () => {
+    expect(formatCompactNumber(394_300_000_000)).toBe('$394.3B');
+  });
+
+  test('formats millions', () => {
+    expect(formatCompactNumber(1_200_000)).toBe('$1.2M');
+  });
+
+  test('formats thousands', () => {
+    expect(formatCompactNumber(45_000)).toBe('$45K');
+  });
+
+  test('formats small numbers without suffix', () => {
+    expect(formatCompactNumber(999)).toBe('$999');
+  });
+
+  test('formats whole billions without decimal', () => {
+    expect(formatCompactNumber(2_000_000_000)).toBe('$2B');
+  });
+
+  test('formats trillions', () => {
+    expect(formatCompactNumber(1_500_000_000_000)).toBe('$1.5T');
+  });
+
+  test('handles negative values', () => {
+    expect(formatCompactNumber(-500_000_000)).toBe('$-500M');
+  });
+});
+
+describe('parseNumericValue', () => {
+  test('parses plain number', () => {
+    expect(parseNumericValue('1234')).toBe(1234);
+  });
+
+  test('parses dollar amount with commas', () => {
+    expect(parseNumericValue('$1,234,567')).toBe(1234567);
+  });
+
+  test('parses value with B suffix', () => {
+    expect(parseNumericValue('$394.3B')).toBe(394_300_000_000);
+  });
+
+  test('parses value with M suffix', () => {
+    expect(parseNumericValue('$1.2M')).toBe(1_200_000);
+  });
+
+  test('parses value with K suffix', () => {
+    expect(parseNumericValue('45K')).toBe(45_000);
+  });
+
+  test('returns null for non-numeric text', () => {
+    expect(parseNumericValue('Apple')).toBeNull();
+  });
+
+  test('returns null for empty string', () => {
+    expect(parseNumericValue('')).toBeNull();
+  });
+
+  test('parses negative with parentheses', () => {
+    const result = parseNumericValue('($500M)');
+    expect(result).toBe(-500_000_000);
+  });
+});
+
+describe('detectChartOpportunity', () => {
+  test('detects bar chart for label + value columns', () => {
+    const headers = ['Company', 'Revenue'];
+    const rows = [
+      ['Apple', '$394.3B'],
+      ['Google', '$307.4B'],
+      ['Microsoft', '$245.1B'],
+    ];
+    const result = detectChartOpportunity(headers, rows);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('bar');
+    expect(result!.data.labels).toEqual(['Apple', 'Google', 'Microsoft']);
+  });
+
+  test('detects sparkline for date + value columns', () => {
+    const headers = ['Year', 'Revenue'];
+    const rows = [
+      ['2020', '$274.5B'],
+      ['2021', '$365.8B'],
+      ['2022', '$394.3B'],
+    ];
+    const result = detectChartOpportunity(headers, rows);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('sparkline');
+  });
+
+  test('detects sparkline for quarter dates', () => {
+    const headers = ['Period', 'EPS'];
+    const rows = [
+      ['Q1 2024', '$1.50'],
+      ['Q2 2024', '$1.62'],
+      ['Q3 2024', '$1.78'],
+    ];
+    const result = detectChartOpportunity(headers, rows);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('sparkline');
+  });
+
+  test('returns null for single row', () => {
+    const result = detectChartOpportunity(['A', 'B'], [['x', '1']]);
+    expect(result).toBeNull();
+  });
+
+  test('returns null for non-numeric data', () => {
+    const headers = ['Name', 'Status'];
+    const rows = [
+      ['Alice', 'Active'],
+      ['Bob', 'Inactive'],
+    ];
+    expect(detectChartOpportunity(headers, rows)).toBeNull();
+  });
+
+  test('returns null for single column', () => {
+    expect(detectChartOpportunity(['A'], [['x'], ['y']])).toBeNull();
+  });
+});
+
+describe('renderBarChart', () => {
+  test('renders non-empty output', () => {
+    const result = renderBarChart({
+      labels: ['Apple', 'Google', 'MSFT'],
+      values: [394.3e9, 307.4e9, 245.1e9],
+      header: 'Company',
+      valueHeader: 'Revenue',
+    });
+    expect(result).toContain('📊');
+    expect(result).toContain('Revenue');
+    expect(result).toContain('Apple');
+    expect(result).toContain('Google');
+    expect(result).toContain('MSFT');
+  });
+
+  test('returns empty string for empty data', () => {
+    expect(renderBarChart({ labels: [], values: [], header: '', valueHeader: '' })).toBe('');
+  });
+
+  test('returns empty string when all values are zero', () => {
+    expect(
+      renderBarChart({ labels: ['A', 'B'], values: [0, 0], header: '', valueHeader: 'X' }),
+    ).toBe('');
+  });
+
+  test('truncates long labels', () => {
+    const result = renderBarChart({
+      labels: ['A very long company name here'],
+      values: [100],
+      header: 'Name',
+      valueHeader: 'Val',
+    });
+    // Label should be truncated to 16 chars
+    expect(result.length).toBeGreaterThan(0);
+  });
+});
+
+describe('renderSparkline', () => {
+  test('renders trend with start/end values', () => {
+    const result = renderSparkline({
+      labels: ['2020', '2021', '2022', '2023', '2024'],
+      values: [274.5e9, 365.8e9, 394.3e9, 383.3e9, 391e9],
+      header: 'Year',
+      valueHeader: 'AAPL Revenue',
+    });
+    expect(result).toContain('📈');
+    expect(result).toContain('AAPL Revenue');
+    expect(result).toContain('2020');
+    expect(result).toContain('2024');
+    expect(result).toContain('→');
+  });
+
+  test('shows positive change in green', () => {
+    const result = renderSparkline({
+      labels: ['2020', '2024'],
+      values: [100, 200],
+      header: 'Year',
+      valueHeader: 'Revenue',
+    });
+    expect(result).toContain('+');
+  });
+
+  test('returns empty for single data point', () => {
+    expect(
+      renderSparkline({ labels: ['2024'], values: [100], header: '', valueHeader: '' }),
+    ).toBe('');
+  });
+
+  test('handles first value of zero without crashing', () => {
+    const result = renderSparkline({
+      labels: ['2020', '2024'],
+      values: [0, 100],
+      header: 'Year',
+      valueHeader: 'Revenue',
+    });
+    expect(result).toContain('+0.0%');
+  });
+});
+
+describe('transformChartsInResponse', () => {
+  test('appends bar chart below a qualifying table', () => {
+    const markdown = [
+      '| Company | Revenue |',
+      '|---------|---------|',
+      '| Apple | $394.3B |',
+      '| Google | $307.4B |',
+      '| MSFT | $245.1B |',
+    ].join('\n');
+
+    const result = transformChartsInResponse(markdown);
+    expect(result).toContain('📊');
+    expect(result).toContain(markdown); // original table preserved
+  });
+
+  test('appends sparkline for time-series table', () => {
+    const markdown = [
+      '| Year | Revenue |',
+      '|------|---------|',
+      '| 2020 | $274.5B |',
+      '| 2021 | $365.8B |',
+      '| 2022 | $394.3B |',
+    ].join('\n');
+
+    const result = transformChartsInResponse(markdown);
+    expect(result).toContain('📈');
+  });
+
+  test('does not modify text without tables', () => {
+    const text = 'Hello world, no tables here.';
+    expect(transformChartsInResponse(text)).toBe(text);
+  });
+
+  test('does not modify non-chartable tables', () => {
+    const markdown = [
+      '| Name | Status |',
+      '|------|--------|',
+      '| Alice | Active |',
+      '| Bob | Inactive |',
+    ].join('\n');
+
+    expect(transformChartsInResponse(markdown)).toBe(markdown);
+  });
+});

--- a/src/utils/charts.ts
+++ b/src/utils/charts.ts
@@ -1,0 +1,240 @@
+/**
+ * Terminal chart rendering for financial data.
+ *
+ * Detects chartable markdown tables and appends Unicode
+ * bar charts or sparklines below them.
+ */
+
+import chalk from 'chalk';
+import { colors, dimensions } from '../theme.js';
+import { parseMarkdownTable } from './markdown-table.js';
+
+// ── Types ──────────────────────────────────────────────────
+
+interface ChartData {
+  labels: string[];
+  values: number[];
+  header: string;
+  valueHeader: string;
+}
+
+type ChartType = 'bar' | 'sparkline';
+
+interface ChartOpportunity {
+  type: ChartType;
+  data: ChartData;
+}
+
+// ── Number formatting ──────────────────────────────────────
+
+const SUFFIXES: [number, string][] = [
+  [1e12, 'T'],
+  [1e9, 'B'],
+  [1e6, 'M'],
+  [1e3, 'K'],
+];
+
+/** Format large numbers compactly: 1234567890 → "1.2B" */
+export function formatCompactNumber(value: number): string {
+  const abs = Math.abs(value);
+  for (const [threshold, suffix] of SUFFIXES) {
+    if (abs >= threshold) {
+      const scaled = value / threshold;
+      const formatted = scaled % 1 === 0 ? scaled.toFixed(0) : scaled.toFixed(1);
+      return `$${formatted}${suffix}`;
+    }
+  }
+  return `$${value.toLocaleString('en-US')}`;
+}
+
+/** Strip currency symbols, commas, and suffix multipliers to get a raw number. */
+export function parseNumericValue(raw: string): number | null {
+  const cleaned = raw.trim();
+  if (!cleaned) return null;
+
+  // Match optional sign, optional $, digits with commas/dots, optional suffix
+  const m = cleaned.match(/^[($-]*\$?\s*([-+]?[\d,]+\.?\d*)\s*([TBMK%]?)[\s)]*$/i);
+  if (!m) return null;
+
+  let num = parseFloat(m[1].replace(/,/g, ''));
+  if (isNaN(num)) return null;
+
+  const suffix = m[2].toUpperCase();
+  if (suffix === 'T') num *= 1e12;
+  else if (suffix === 'B') num *= 1e9;
+  else if (suffix === 'M') num *= 1e6;
+  else if (suffix === 'K') num *= 1e3;
+
+  if (cleaned.startsWith('(') || cleaned.startsWith('-')) {
+    num = -Math.abs(num);
+  }
+
+  return num;
+}
+
+// ── Date detection ─────────────────────────────────────────
+
+const DATE_PATTERNS = [
+  /^\d{4}[-/]\d{1,2}([-/]\d{1,2})?$/, // 2024-01, 2024-01-15
+  /^\d{1,2}[-/]\d{1,2}[-/]\d{2,4}$/,  // 01/15/2024
+  /^(Q[1-4])\s*\d{4}$/i,               // Q1 2024
+  /^(FY|CY)?\s*\d{4}$/i,               // FY2024, 2024
+  /^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)/i, // Jan 2024
+];
+
+function looksLikeDate(value: string): boolean {
+  return DATE_PATTERNS.some((p) => p.test(value.trim()));
+}
+
+// ── Chart detection ────────────────────────────────────────
+
+/**
+ * Analyze a parsed table and determine if it's suitable for charting.
+ * Returns null if the table isn't a good chart candidate.
+ */
+export function detectChartOpportunity(
+  headers: string[],
+  rows: string[][],
+): ChartOpportunity | null {
+  if (headers.length < 2 || rows.length < 2) return null;
+
+  // Find the first numeric column (skip first column — likely labels)
+  let valueColIdx = -1;
+  for (let col = 1; col < headers.length; col++) {
+    const numericCount = rows.filter((r) => parseNumericValue(r[col] ?? '') !== null).length;
+    if (numericCount >= rows.length * 0.6) {
+      valueColIdx = col;
+      break;
+    }
+  }
+  if (valueColIdx === -1) return null;
+
+  const labels = rows.map((r) => r[0]?.trim() ?? '');
+  const values = rows.map((r) => parseNumericValue(r[valueColIdx] ?? '') ?? 0);
+
+  const data: ChartData = {
+    labels,
+    values,
+    header: headers[0],
+    valueHeader: headers[valueColIdx],
+  };
+
+  // If labels look like dates → sparkline, otherwise → bar
+  const dateCount = labels.filter(looksLikeDate).length;
+  const type: ChartType = dateCount >= labels.length * 0.6 ? 'sparkline' : 'bar';
+
+  return { type, data };
+}
+
+// ── Bar chart renderer ─────────────────────────────────────
+
+const BAR_BLOCKS = ['▏', '▎', '▍', '▌', '▋', '▊', '▉', '█'];
+
+function buildBar(ratio: number, maxWidth: number): string {
+  const fullBlocks = Math.floor(ratio * maxWidth);
+  const remainder = (ratio * maxWidth) - fullBlocks;
+  const partialIdx = Math.round(remainder * (BAR_BLOCKS.length - 1));
+
+  let bar = '█'.repeat(fullBlocks);
+  if (partialIdx > 0 && fullBlocks < maxWidth) {
+    bar += BAR_BLOCKS[partialIdx];
+  }
+  return bar || BAR_BLOCKS[0]; // At least one sliver
+}
+
+export function renderBarChart(data: ChartData): string {
+  const { labels, values, valueHeader } = data;
+  if (labels.length === 0) return '';
+
+  const maxVal = Math.max(...values.map(Math.abs));
+  if (maxVal === 0) return '';
+
+  const maxLabelLen = Math.min(
+    Math.max(...labels.map((l) => l.length)),
+    16,
+  );
+  const formattedValues = values.map(formatCompactNumber);
+  const maxValLen = Math.max(...formattedValues.map((v) => v.length));
+  const barMaxWidth = Math.max(dimensions.boxWidth - maxLabelLen - maxValLen - 6, 10); // padding, min 10
+
+  const lines: string[] = [];
+  lines.push(`  📊 ${valueHeader}`);
+  lines.push('');
+
+  for (let i = 0; i < labels.length; i++) {
+    const label = labels[i].slice(0, 16).padEnd(maxLabelLen);
+    const ratio = Math.abs(values[i]) / maxVal;
+    const bar = chalk.hex(colors.primary)(buildBar(ratio, barMaxWidth));
+    const valStr = formattedValues[i].padStart(maxValLen);
+    lines.push(`  ${label}  ${bar}  ${valStr}`);
+  }
+
+  return lines.join('\n');
+}
+
+// ── Sparkline renderer ─────────────────────────────────────
+
+const SPARK_CHARS = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+
+export function renderSparkline(data: ChartData): string {
+  const { labels, values, valueHeader } = data;
+  if (values.length < 2) return '';
+
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+
+  const spark = values
+    .map((v) => {
+      const idx = Math.round(((v - min) / range) * (SPARK_CHARS.length - 1));
+      return SPARK_CHARS[idx];
+    })
+    .join('');
+
+  const first = values[0];
+  const last = values[values.length - 1];
+  const change = first !== 0 ? ((last - first) / Math.abs(first)) * 100 : 0;
+  const changeStr = change >= 0 ? `+${change.toFixed(1)}%` : `${change.toFixed(1)}%`;
+
+  const firstLabel = labels[0] ?? '';
+  const lastLabel = labels[labels.length - 1] ?? '';
+  const period = firstLabel && lastLabel ? ` (${firstLabel}–${lastLabel})` : '';
+
+  const lines: string[] = [];
+  lines.push(`  📈 ${valueHeader}${period}`);
+  lines.push(
+    `  ${chalk.hex(colors.primary)(spark)}  ${formatCompactNumber(first)} → ${formatCompactNumber(last)} ${change >= 0 ? chalk.green(changeStr) : chalk.red(changeStr)}`,
+  );
+
+  return lines.join('\n');
+}
+
+// ── Integration ────────────────────────────────────────────
+
+/**
+ * Scan content for markdown tables, detect chart opportunities,
+ * and append charts below each qualifying table.
+ */
+export function transformChartsInResponse(content: string): string {
+  // Match markdown tables (lines with pipes, including separator)
+  const tableRegex = /^(\|[^\n]+\|\n\|[-:| \t]+\|(?:\n\|[^\n]+\|)*)/gm;
+
+  return content.replace(tableRegex, (match) => {
+    const parsed = parseMarkdownTable(match);
+    if (!parsed || parsed.headers.length < 2 || parsed.rows.length < 2) {
+      return match;
+    }
+
+    const opportunity = detectChartOpportunity(parsed.headers, parsed.rows);
+    if (!opportunity) return match;
+
+    const chart =
+      opportunity.type === 'sparkline'
+        ? renderSparkline(opportunity.data)
+        : renderBarChart(opportunity.data);
+
+    if (!chart) return match;
+
+    return `${match}\n\n${chart}`;
+  });
+}

--- a/src/utils/markdown-table.ts
+++ b/src/utils/markdown-table.ts
@@ -6,6 +6,7 @@
  */
 
 import chalk from 'chalk';
+import { transformChartsInResponse } from './charts.js';
 
 // Box-drawing characters
 const BOX = {
@@ -221,6 +222,7 @@ export function transformBold(content: string): string {
  */
 export function formatResponse(content: string): string {
   let result = content;
+  result = transformChartsInResponse(result);
   result = transformMarkdownTables(result);
   result = transformBold(result);
   return result;


### PR DESCRIPTION
Closes #63

Adds automatic Unicode chart rendering for financial data in agent responses. Charts are appended **below** existing tables — the original table output is preserved.

## What it does

When the agent returns a markdown table with numeric data, the formatter now detects chart opportunities and appends a visual:

**Bar chart** — for comparison data (e.g. company revenue side-by-side):
```
  📊 Revenue
  
  Apple             ██████████████████████████████████████  $394.3B
  Google            ████████████████████████████████        $307.4B
  Microsoft         ████████████████████████████            $245.1B
```

**Sparkline** — for time-series trends (e.g. quarterly earnings):
```
  📈 Revenue (2020–2024)
  ▁▂▅▇█  $274.5B → $394.3B (+43.6%)
```

## How it works

- `detectChartOpportunity()` analyzes parsed table columns — if it finds a label/date column paired with a numeric column, it suggests a chart type
- Date-like labels (years, quarters, `YYYY-MM`) → sparkline; otherwise → bar chart
- Integrated into the existing `formatResponse()` pipeline, runs before table boxing
- Uses theme colors (`colors.primary`) and respects `dimensions.boxWidth`

## Changes

| File | What |
|------|------|
| `src/utils/charts.ts` | Chart engine — bar chart, sparkline, detection, number formatting |
| `src/utils/charts.test.ts` | 32 tests covering all chart functions and edge cases |
| `src/utils/markdown-table.ts` | 2-line integration into `formatResponse()` |

## Tests

32 new tests, all passing. Full suite (41 tests) green. `bun run typecheck` clean.