### PR TITLE
feat: multi-turn conversation history and deep research interview

### DIFF
--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -24,13 +24,13 @@ export function getCurrentDate(): string {
  */
 function buildSkillsSection(): string {
   const skills = discoverSkills();
-  
+
   if (skills.length === 0) {
     return '';
   }
 
   const skillList = buildSkillMetadataSection();
-  
+
   return `## Available Skills
 
 ${skillList}
@@ -131,6 +131,26 @@ ${buildSkillsSection()}
 - Avoid over-engineering responses - match the scope of your answer to the question
 - Never ask users to provide raw data, paste values, or reference JSON/API internals - users ask questions, they don't have access to financial APIs
 - If data is incomplete, answer with what you have without exposing implementation details
+
+## Deep Research Interview
+
+When a user asks for "deep research", "deep dive", "comprehensive analysis", or "thorough analysis", **interview them first before doing any research or invoking skills**.
+
+Questions (ask ONE at a time, in order):
+1. Goal (buy/sell/hold, thesis, trade, learning)
+2. Time horizon
+3. Focus areas (valuation, growth, risks, moat, etc.)
+4. Output format (thesis, valuation, risk report, comparison, full report)
+5. Comparisons (specific competitors or your pick)
+
+Format rules:
+- Prefix each question with its number: "**Q1:**", "**Q2:**", etc.
+- List options as **letters**: A) ... B) ... C) ... D) ...
+- Always include a final option: "or type your own"
+- Accept any reply: a letter ("B"), a word ("growth"), or a full sentence
+- Acknowledge briefly ("Got it — long-term thesis."), then immediately ask the next question
+- Never re-ask a question. Never dump all questions at once.
+- After Q5, summarize all choices, then invoke the deep-research skill to execute.
 
 ## Response Format
 

--- a/src/skills/deep-research/SKILL.md
+++ b/src/skills/deep-research/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: deep-research
+description: Executes deep, multi-step financial research on a stock or topic. Invoke AFTER the user has been interviewed about their research goals. Pass the user's scoped parameters (goal, time horizon, focus areas, output format, comparisons) as the skill arguments.
+---
+
+# Deep Research Skill
+
+**Important:** This skill is for research execution only. The interview/scoping phase is handled by the system prompt BEFORE this skill is invoked. When invoking this skill, pass the user's answers (goal, time horizon, focus, output, comparisons) as arguments.
+
+## Data Gathering
+
+Based on the scoping answers, gather data using these tools:
+
+### Financials (always)
+- `financial_search`: "[TICKER] annual income statements last 5 years"
+- `financial_search`: "[TICKER] financial metrics snapshot"
+- `financial_search`: "[TICKER] latest balance sheet"
+
+### Growth & Drivers (if focus includes growth or thesis)
+- `financial_search`: "[TICKER] quarterly revenue and earnings last 8 quarters"
+- `financial_search`: "[TICKER] analyst estimates"
+- `web_search`: "[COMPANY] growth strategy 2025 2026"
+
+### Risks (if focus includes risks)
+- `web_search`: "[COMPANY] risks regulation competition"
+- `financial_search`: "[TICKER] insider trades last 6 months"
+
+### Competitive Position (if focus includes competition or comparisons)
+- `financial_search`: "[COMP_TICKER] financial metrics snapshot" (for each competitor)
+- `web_search`: "[COMPANY] vs [COMPETITOR] market share"
+
+### Valuation (if focus includes valuation)
+- Use the `dcf-valuation` skill if available
+- Otherwise: `financial_search`: "[TICKER] price snapshot" + calculate P/E, EV/EBITDA, PEG from gathered data
+
+## Analysis & Output
+
+Structure the final output based on what the user requested:
+
+### Bull / Base / Bear Thesis
+- **Bull case**: best realistic scenario with catalysts and upside %
+- **Base case**: most likely outcome with fair value estimate
+- **Bear case**: key risks and downside %
+
+### Competitor Comparison
+- Side-by-side table: revenue, margins, growth, valuation multiples
+- Qualitative moat comparison (1–2 sentences each)
+
+### Risk Report
+- Top 5 risks ranked by impact × probability
+- For each: what to watch (metric or signal) and trigger level
+
+### Full Report
+- Executive summary (3–4 sentences)
+- All sections above combined
+- "What to watch" checklist for quarterly monitoring
+
+## Output Rules
+
+- Lead with the key finding — don't bury the conclusion
+- Use tables for comparative data
+- Keep total output concise — quality over length
+- Include specific numbers, not vague qualifiers
+- End with 3–5 actionable "things to watch" going forward


### PR DESCRIPTION
- Pass full HumanMessage/AIMessage pairs to LLM instead of text serialization
- Add optional messages param to callLlm for proper multi-turn context
- Cap history at N turns with summaries for older turns (configurable via env)
- Add deep research interview flow in system prompt (Q1-Q5 with MCQ)
- Add deep-research skill for research execution (data gathering + analysis)
- Split interview (system prompt) from execution (skill) to avoid skill reload per turn