### PR TITLE
feat: add perplexity as a web search provider

### DIFF
--- a/env.example
+++ b/env.example
@@ -13,8 +13,9 @@ OLLAMA_BASE_URL=http://127.0.0.1:11434
 # Stock Market API Key
 FINANCIAL_DATASETS_API_KEY=your-api-key
 
-# Web Search API Keys (Exa preferred, Tavily fallback)
+# Web Search API Keys (Exa → Perplexity → Tavily)
 EXASEARCH_API_KEY=your-api-key
+PERPLEXITY_API_KEY=your-api-key
 TAVILY_API_KEY=your-api-key
 
 # LangSmith 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,6 +1,6 @@
 import { StructuredToolInterface } from '@langchain/core/tools';
 import { createFinancialSearch, createFinancialMetrics, createReadFilings } from './finance/index.js';
-import { exaSearch, tavilySearch } from './search/index.js';
+import { exaSearch, perplexitySearch, tavilySearch } from './search/index.js';
 import { skillTool, SKILL_TOOL_DESCRIPTION } from './skill.js';
 import { webFetchTool } from './fetch/index.js';
 import { browserTool } from './browser/index.js';
@@ -55,11 +55,17 @@ export function getToolRegistry(model: string): RegisteredTool[] {
     },
   ];
 
-  // Include web_search if Exa or Tavily API key is configured (Exa preferred)
+  // Include web_search if Exa, Perplexity, or Tavily API key is configured (Exa → Perplexity → Tavily)
   if (process.env.EXASEARCH_API_KEY) {
     tools.push({
       name: 'web_search',
       tool: exaSearch,
+      description: WEB_SEARCH_DESCRIPTION,
+    });
+  } else if (process.env.PERPLEXITY_API_KEY) {
+    tools.push({
+      name: 'web_search',
+      tool: perplexitySearch,
       description: WEB_SEARCH_DESCRIPTION,
     });
   } else if (process.env.TAVILY_API_KEY) {

--- a/src/tools/search/index.ts
+++ b/src/tools/search/index.ts
@@ -1,2 +1,3 @@
 export { tavilySearch } from './tavily.js';
 export { exaSearch } from './exa.js';
+export { perplexitySearch } from './perplexity.js';

--- a/src/tools/search/perplexity.ts
+++ b/src/tools/search/perplexity.ts
@@ -1,0 +1,89 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+import { formatToolResult } from '../types.js';
+import { logger } from '@/utils';
+
+const PERPLEXITY_API_URL = 'https://api.perplexity.ai/chat/completions';
+const SONAR_MODEL = 'sonar';
+
+interface PerplexitySearchResult {
+  title: string;
+  url: string;
+  date?: string | null;
+  snippet?: string;
+}
+
+interface PerplexityCompletionResponse {
+  choices?: Array<{
+    message?: { content?: string | null };
+  }>;
+  citations?: string[] | null;
+  search_results?: PerplexitySearchResult[] | null;
+}
+
+async function callPerplexity(query: string): Promise<PerplexityCompletionResponse> {
+  const apiKey = process.env.PERPLEXITY_API_KEY;
+  if (!apiKey) {
+    throw new Error('PERPLEXITY_API_KEY is not set');
+  }
+
+  const response = await fetch(PERPLEXITY_API_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: SONAR_MODEL,
+      messages: [{ role: 'user' as const, content: query }],
+      max_tokens: 1024,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Perplexity API ${response.status}: ${text}`);
+  }
+
+  return response.json() as Promise<PerplexityCompletionResponse>;
+}
+
+export const perplexitySearch = new DynamicStructuredTool({
+  name: 'web_search',
+  description:
+    'Search the web for current information on any topic. Returns a grounded, citation-backed answer with source URLs.',
+  schema: z.object({
+    query: z.string().describe('The search query to look up on the web'),
+  }),
+  func: async (input) => {
+    try {
+      const res = await callPerplexity(input.query);
+      const content = res.choices?.[0]?.message?.content ?? '';
+      const urls: string[] = [];
+      if (Array.isArray(res.citations)) {
+        urls.push(...res.citations);
+      }
+      if (Array.isArray(res.search_results)) {
+        for (const r of res.search_results) {
+          if (r?.url && !urls.includes(r.url)) {
+            urls.push(r.url);
+          }
+        }
+      }
+      const data = {
+        answer: content,
+        results:
+          res.search_results?.map((r) => ({
+            title: r.title,
+            url: r.url,
+            snippet: r.snippet ?? undefined,
+          })) ?? [],
+      };
+      return formatToolResult(data, urls.length ? urls : undefined);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`[Perplexity API] error: ${message}`);
+      throw new Error(`[Perplexity API] ${message}`);
+    }
+  },
+});


### PR DESCRIPTION
## Summary
Adds Perplexity as a web search backend alongside Exa and Tavily. Web search provider order is Exa → Perplexity → Tavily (first configured API key wins).

## Behavior
- Interface: Same web_search tool (name, query input, shared WEB_SEARCH_DESCRIPTION).
- Auth: PERPLEXITY_API_KEY (Bearer). No new dependencies; uses fetch to https://api.perplexity.ai/chat/completions.
- Response: Answer text + search_results/citations mapped to sourceUrls so the agent gets both the answer and links. Can reduce follow-up web_fetch calls and token usage.
