### PR TITLE
feat(finance): add multi-provider market data fallback (Financial Datasets + FMP + Alpha Vantage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ Dexter takes complex financial questions and turns them into clear, step-by-step
 
 - [Bun](https://bun.com) runtime (v1.0 or higher)
 - OpenAI API key (get [here](https://platform.openai.com/api-keys))
-- Financial Datasets API key (get [here](https://financialdatasets.ai))
+- Finance data API key (choose at least one):
+  - Financial Datasets (get [here](https://financialdatasets.ai))
+  - Financial Modeling Prep / FMP (get [here](https://financialmodelingprep.com))
+  - Alpha Vantage (get [here](https://www.alphavantage.co/support/#api-key))
 - Exa API key (get [here](https://exa.ai)) - optional, for web search
 
 #### Installing Bun
@@ -83,8 +86,12 @@ cp env.example .env
 # XAI_API_KEY=your-xai-api-key (optional)
 # OPENROUTER_API_KEY=your-openrouter-api-key (optional)
 
-# Institutional-grade market data for agents; AAPL, NVDA, MSFT are free
-# FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
+	# Institutional-grade market data for agents; AAPL, NVDA, MSFT are free
+	# Finance provider selection: auto (default), financialdatasets, fmp, alphavantage
+	# FINANCE_DATA_PROVIDER=auto
+	# FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
+	# FMP_API_KEY=your-fmp-api-key
+	# ALPHAVANTAGE_API_KEY=your-alphavantage-api-key
 
 # (Optional) If using Ollama locally
 # OLLAMA_BASE_URL=http://127.0.0.1:11434

--- a/env.example
+++ b/env.example
@@ -10,8 +10,12 @@ DEEPSEEK_API_KEY=your-api-key
 # Ollama (Local LLM)
 OLLAMA_BASE_URL=http://127.0.0.1:11434
 
-# Stock Market API Key
+# Finance Data Providers (set at least one)
+# Provider selection: auto (default), financialdatasets, fmp, alphavantage
+FINANCE_DATA_PROVIDER=auto
 FINANCIAL_DATASETS_API_KEY=your-api-key
+FMP_API_KEY=your-api-key
+ALPHAVANTAGE_API_KEY=your-api-key
 
 # Web Search API Keys (Exa → Perplexity → Tavily)
 EXASEARCH_API_KEY=your-api-key

--- a/src/tools/finance/company_facts.ts
+++ b/src/tools/finance/company_facts.ts
@@ -1,7 +1,10 @@
 import { DynamicStructuredTool } from '@langchain/core/tools';
 import { z } from 'zod';
-import { callApi } from './api.js';
 import { formatToolResult } from '../types.js';
+import { runFinanceProviderChain } from './providers/fallback.js';
+import { fdCompanyFacts } from './providers/financialdatasets.js';
+import { fmpCompanyFacts } from './providers/fmp.js';
+import { avCompanyFacts } from './providers/alphavantage.js';
 
 const CompanyFactsInputSchema = z.object({
   ticker: z
@@ -14,7 +17,30 @@ export const getCompanyFacts = new DynamicStructuredTool({
   description: `Retrieves company facts and metadata for a given ticker, including sector, industry, market cap, number of employees, listing date, exchange, location, weighted average shares,  website. Useful for getting an overview of a company's profile and basic information.`,
   schema: CompanyFactsInputSchema,
   func: async (input) => {
-    const { data, url } = await callApi('/company/facts', { ticker: input.ticker });
-    return formatToolResult(data.company_facts || {}, [url]);
+    const result = await runFinanceProviderChain('get_company_facts', [
+      {
+        provider: 'financialdatasets',
+        run: async () => {
+          const { data, url } = await fdCompanyFacts(input.ticker);
+          return { data, sourceUrls: [url] };
+        },
+      },
+      {
+        provider: 'fmp',
+        run: async () => {
+          const { data, url } = await fmpCompanyFacts(input.ticker);
+          return { data, sourceUrls: [url] };
+        },
+      },
+      {
+        provider: 'alphavantage',
+        run: async () => {
+          const { data, url } = await avCompanyFacts(input.ticker);
+          return { data, sourceUrls: [url] };
+        },
+      },
+    ]);
+
+    return formatToolResult(result.data, result.sourceUrls);
   },
 });

--- a/src/tools/finance/prices.ts
+++ b/src/tools/finance/prices.ts
@@ -1,7 +1,10 @@
 import { DynamicStructuredTool } from '@langchain/core/tools';
 import { z } from 'zod';
-import { callApi } from './api.js';
 import { formatToolResult } from '../types.js';
+import { runFinanceProviderChain } from './providers/fallback.js';
+import { fdPriceSnapshot, fdPrices } from './providers/financialdatasets.js';
+import { fmpPriceSnapshot, fmpPrices } from './providers/fmp.js';
+import { avPriceSnapshot, avPrices } from './providers/alphavantage.js';
 
 const PriceSnapshotInputSchema = z.object({
   ticker: z
@@ -16,9 +19,31 @@ export const getPriceSnapshot = new DynamicStructuredTool({
   description: `Fetches the most recent price snapshot for a specific stock ticker, including the latest price, trading volume, and other open, high, low, and close price data.`,
   schema: PriceSnapshotInputSchema,
   func: async (input) => {
-    const params = { ticker: input.ticker };
-    const { data, url } = await callApi('/prices/snapshot/', params);
-    return formatToolResult(data.snapshot || {}, [url]);
+    const result = await runFinanceProviderChain('get_price_snapshot', [
+      {
+        provider: 'financialdatasets',
+        run: async () => {
+          const { data, url } = await fdPriceSnapshot(input.ticker);
+          return { data, sourceUrls: [url] };
+        },
+      },
+      {
+        provider: 'fmp',
+        run: async () => {
+          const { data, url } = await fmpPriceSnapshot(input.ticker);
+          return { data, sourceUrls: [url] };
+        },
+      },
+      {
+        provider: 'alphavantage',
+        run: async () => {
+          const { data, url } = await avPriceSnapshot(input.ticker);
+          return { data, sourceUrls: [url] };
+        },
+      },
+    ]);
+
+    return formatToolResult(result.data, result.sourceUrls);
   },
 });
 
@@ -45,19 +70,56 @@ export const getPrices = new DynamicStructuredTool({
   description: `Retrieves historical price data for a stock over a specified date range, including open, high, low, close prices, and volume.`,
   schema: PricesInputSchema,
   func: async (input) => {
-    const params = {
-      ticker: input.ticker,
-      interval: input.interval,
-      interval_multiplier: input.interval_multiplier,
-      start_date: input.start_date,
-      end_date: input.end_date,
-    };
     // Cache when the date window is fully closed (OHLCV data is final)
     const endDate = new Date(input.end_date + 'T00:00:00');
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-    const { data, url } = await callApi('/prices/', params, { cacheable: endDate < today });
-    return formatToolResult(data.prices || [], [url]);
+
+    const result = await runFinanceProviderChain('get_prices', [
+      {
+        provider: 'financialdatasets',
+        run: async () => {
+          const { data, url } = await fdPrices(
+            {
+              ticker: input.ticker,
+              interval: input.interval,
+              interval_multiplier: input.interval_multiplier,
+              start_date: input.start_date,
+              end_date: input.end_date,
+            },
+            { cacheable: endDate < today }
+          );
+          return { data, sourceUrls: [url] };
+        },
+      },
+      {
+        provider: 'fmp',
+        run: async () => {
+          const { data, url } = await fmpPrices({
+            ticker: input.ticker,
+            interval: input.interval,
+            interval_multiplier: input.interval_multiplier,
+            start_date: input.start_date,
+            end_date: input.end_date,
+          });
+          return { data, sourceUrls: [url] };
+        },
+      },
+      {
+        provider: 'alphavantage',
+        run: async () => {
+          const { data, url } = await avPrices({
+            ticker: input.ticker,
+            interval: input.interval,
+            interval_multiplier: input.interval_multiplier,
+            start_date: input.start_date,
+            end_date: input.end_date,
+          });
+          return { data, sourceUrls: [url] };
+        },
+      },
+    ]);
+
+    return formatToolResult(result.data, result.sourceUrls);
   },
 });
-

--- a/src/tools/finance/providers/alphavantage.ts
+++ b/src/tools/finance/providers/alphavantage.ts
@@ -1,0 +1,352 @@
+import { MissingApiKeyError } from './types.js';
+
+const BASE_URL = 'https://www.alphavantage.co/query';
+
+function requireAlphaVantageApiKey(): string {
+  const key = process.env.ALPHAVANTAGE_API_KEY;
+  if (!key || !key.trim() || key.trim().startsWith('your-')) {
+    throw new MissingApiKeyError('ALPHAVANTAGE_API_KEY');
+  }
+  return key.trim();
+}
+
+function redactApiKey(url: URL): string {
+  const copy = new URL(url.toString());
+  copy.searchParams.delete('apikey');
+  return copy.toString();
+}
+
+function parseAlphaVantageError(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const obj = payload as Record<string, unknown>;
+  const fields = ['Error Message', 'Information', 'Note'];
+  for (const f of fields) {
+    const v = obj[f];
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  return null;
+}
+
+async function callAlphaVantage<T = unknown>(
+  params: Record<string, string | number | undefined>
+): Promise<{ data: T; url: string }> {
+  const apiKey = requireAlphaVantageApiKey();
+  const url = new URL(BASE_URL);
+  for (const [k, v] of Object.entries(params)) {
+    if (v === undefined || v === null) continue;
+    url.searchParams.set(k, String(v));
+  }
+  url.searchParams.set('apikey', apiKey);
+
+  const response = await fetch(url.toString());
+  if (!response.ok) {
+    throw new Error(`Alpha Vantage request failed: ${response.status} ${response.statusText}`);
+  }
+  const data = (await response.json()) as T;
+  const err = parseAlphaVantageError(data);
+  if (err) throw new Error(`Alpha Vantage error: ${err}`);
+
+  return { data, url: redactApiKey(url) };
+}
+
+function toDateOnly(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const match = value.match(/^(\d{4}-\d{2}-\d{2})/);
+  return match ? match[1] : null;
+}
+
+export async function avPriceSnapshot(ticker: string): Promise<{ data: unknown; url: string }> {
+  const { data, url } = await callAlphaVantage<Record<string, unknown>>({
+    function: 'GLOBAL_QUOTE',
+    symbol: ticker.toUpperCase(),
+  });
+  const quote = (data['Global Quote'] as Record<string, unknown> | undefined) ?? {};
+  const parsed = {
+    symbol: quote['01. symbol'],
+    open: quote['02. open'],
+    high: quote['03. high'],
+    low: quote['04. low'],
+    price: quote['05. price'],
+    volume: quote['06. volume'],
+    latestTradingDay: quote['07. latest trading day'],
+    previousClose: quote['08. previous close'],
+    change: quote['09. change'],
+    changePercent: quote['10. change percent'],
+  };
+  return { data: parsed, url };
+}
+
+type SeriesRow = { date: string; open: string; high: string; low: string; close: string; volume: string } & Record<
+  string,
+  unknown
+>;
+
+function extractTimeSeries(payload: Record<string, unknown>): Record<string, Record<string, unknown>> | null {
+  for (const [k, v] of Object.entries(payload)) {
+    if (k.toLowerCase().includes('time series') && v && typeof v === 'object') {
+      return v as Record<string, Record<string, unknown>>;
+    }
+  }
+  return null;
+}
+
+function mapSeriesRows(
+  series: Record<string, Record<string, unknown>>,
+  datePredicate: (date: string) => boolean
+): SeriesRow[] {
+  const rows: SeriesRow[] = [];
+  for (const [timestamp, values] of Object.entries(series)) {
+    const date = toDateOnly(timestamp);
+    if (!date) continue;
+    if (!datePredicate(date)) continue;
+    const v = values as Record<string, unknown>;
+    rows.push({
+      date: timestamp,
+      open: String(v['1. open'] ?? ''),
+      high: String(v['2. high'] ?? ''),
+      low: String(v['3. low'] ?? ''),
+      close: String(v['4. close'] ?? ''),
+      volume: String(v['5. volume'] ?? ''),
+      ...v,
+    });
+  }
+  rows.sort((a, b) => String(a.date).localeCompare(String(b.date)));
+  return rows;
+}
+
+export async function avPrices(params: {
+  ticker: string;
+  interval: 'minute' | 'day' | 'week' | 'month' | 'year';
+  interval_multiplier: number;
+  start_date: string;
+  end_date: string;
+}): Promise<{ data: unknown; url: string }> {
+  const symbol = params.ticker.toUpperCase();
+  const inRange = (date: string) => date >= params.start_date && date <= params.end_date;
+
+  if (params.interval === 'minute') {
+    const allowed = new Set([1, 5, 15, 30, 60]);
+    if (!allowed.has(params.interval_multiplier)) {
+      throw new Error(`Alpha Vantage intraday supports interval_multiplier one of: ${Array.from(allowed).join(', ')}`);
+    }
+    const { data, url } = await callAlphaVantage<Record<string, unknown>>({
+      function: 'TIME_SERIES_INTRADAY',
+      symbol,
+      interval: `${params.interval_multiplier}min`,
+      outputsize: 'full',
+    });
+    const series = extractTimeSeries(data);
+    if (!series) return { data: [], url };
+    const rows = mapSeriesRows(series, inRange);
+    return { data: rows, url };
+  }
+
+  if (params.interval === 'day') {
+    const { data, url } = await callAlphaVantage<Record<string, unknown>>({
+      function: 'TIME_SERIES_DAILY_ADJUSTED',
+      symbol,
+      outputsize: 'full',
+    });
+    const series = extractTimeSeries(data);
+    if (!series) return { data: [], url };
+    const rows = mapSeriesRows(series, inRange);
+    return { data: rows, url };
+  }
+
+  if (params.interval === 'week') {
+    const { data, url } = await callAlphaVantage<Record<string, unknown>>({
+      function: 'TIME_SERIES_WEEKLY_ADJUSTED',
+      symbol,
+    });
+    const series = extractTimeSeries(data);
+    if (!series) return { data: [], url };
+    const rows = mapSeriesRows(series, inRange);
+    return { data: rows, url };
+  }
+
+  if (params.interval === 'month') {
+    const { data, url } = await callAlphaVantage<Record<string, unknown>>({
+      function: 'TIME_SERIES_MONTHLY_ADJUSTED',
+      symbol,
+    });
+    const series = extractTimeSeries(data);
+    if (!series) return { data: [], url };
+    const rows = mapSeriesRows(series, inRange);
+    return { data: rows, url };
+  }
+
+  // year: derive from monthly
+  const { data, url } = await callAlphaVantage<Record<string, unknown>>({
+    function: 'TIME_SERIES_MONTHLY_ADJUSTED',
+    symbol,
+  });
+  const series = extractTimeSeries(data);
+  if (!series) return { data: [], url };
+  const monthly = mapSeriesRows(series, () => true);
+
+  const byYear = new Map<string, SeriesRow[]>();
+  for (const row of monthly) {
+    const dateOnly = toDateOnly(row.date);
+    if (!dateOnly) continue;
+    const year = dateOnly.slice(0, 4);
+    if (!byYear.has(year)) byYear.set(year, []);
+    byYear.get(year)!.push(row);
+  }
+
+  const years: SeriesRow[] = [];
+  for (const [year, rows] of byYear.entries()) {
+    rows.sort((a, b) => String(a.date).localeCompare(String(b.date)));
+    const first = rows[0]!;
+    const last = rows[rows.length - 1]!;
+    let high = -Infinity;
+    let low = Infinity;
+    let volume = 0;
+    for (const r of rows) {
+      const h = Number(r.high);
+      const l = Number(r.low);
+      const vol = Number(r.volume);
+      if (Number.isFinite(h)) high = Math.max(high, h);
+      if (Number.isFinite(l)) low = Math.min(low, l);
+      if (Number.isFinite(vol)) volume += vol;
+    }
+    const date = `${year}-12-31`;
+    if (!inRange(date)) continue;
+    years.push({
+      date,
+      open: first.open,
+      high: Number.isFinite(high) ? String(high) : '',
+      low: Number.isFinite(low) ? String(low) : '',
+      close: last.close,
+      volume: String(volume),
+    } as SeriesRow);
+  }
+  years.sort((a, b) => String(a.date).localeCompare(String(b.date)));
+  return { data: years, url };
+}
+
+export async function avCompanyFacts(ticker: string): Promise<{ data: unknown; url: string }> {
+  const { data, url } = await callAlphaVantage<Record<string, unknown>>({
+    function: 'OVERVIEW',
+    symbol: ticker.toUpperCase(),
+  });
+  return { data, url };
+}
+
+export async function avNews(params: {
+  ticker: string;
+  limit?: number;
+  start_date?: string;
+  end_date?: string;
+}): Promise<{ data: unknown; url: string }> {
+  const toAlphaTime = (date: string, endOfDay: boolean) =>
+    `${date.replace(/-/g, '')}T${endOfDay ? '2359' : '0000'}`;
+
+  const { data, url } = await callAlphaVantage<Record<string, unknown>>({
+    function: 'NEWS_SENTIMENT',
+    tickers: params.ticker.toUpperCase(),
+    time_from: params.start_date ? toAlphaTime(params.start_date, false) : undefined,
+    time_to: params.end_date ? toAlphaTime(params.end_date, true) : undefined,
+    limit: params.limit,
+  });
+  return { data, url };
+}
+
+type StatementPeriod = 'annual' | 'quarterly' | 'ttm';
+
+function selectReports(payload: Record<string, unknown>, period: StatementPeriod): unknown[] {
+  const annual = Array.isArray(payload.annualReports) ? (payload.annualReports as unknown[]) : [];
+  const quarterly = Array.isArray(payload.quarterlyReports) ? (payload.quarterlyReports as unknown[]) : [];
+  if (period === 'annual') return annual;
+  if (period === 'quarterly') return quarterly;
+  return quarterly.slice(0, 4);
+}
+
+function filterByFiscalDateEnding(rows: unknown[], filters: { gt?: string; gte?: string; lt?: string; lte?: string }): unknown[] {
+  const toDate = (row: unknown) =>
+    row && typeof row === 'object' ? toDateOnly((row as Record<string, unknown>).fiscalDateEnding) : null;
+  return rows.filter((row) => {
+    const date = toDate(row);
+    if (!date) return true;
+    if (filters.gt && !(date > filters.gt)) return false;
+    if (filters.gte && !(date >= filters.gte)) return false;
+    if (filters.lt && !(date < filters.lt)) return false;
+    if (filters.lte && !(date <= filters.lte)) return false;
+    return true;
+  });
+}
+
+export async function avIncomeStatements(params: {
+  ticker: string;
+  period: StatementPeriod;
+  limit: number;
+  report_period_gt?: string;
+  report_period_gte?: string;
+  report_period_lt?: string;
+  report_period_lte?: string;
+}): Promise<{ data: unknown; url: string }> {
+  const { data, url } = await callAlphaVantage<Record<string, unknown>>({
+    function: 'INCOME_STATEMENT',
+    symbol: params.ticker.toUpperCase(),
+  });
+  const rows = selectReports(data, params.period);
+  const filtered = filterByFiscalDateEnding(rows, {
+    gt: params.report_period_gt,
+    gte: params.report_period_gte,
+    lt: params.report_period_lt,
+    lte: params.report_period_lte,
+  });
+  return { data: filtered.slice(0, params.limit), url };
+}
+
+export async function avBalanceSheets(params: {
+  ticker: string;
+  period: StatementPeriod;
+  limit: number;
+  report_period_gt?: string;
+  report_period_gte?: string;
+  report_period_lt?: string;
+  report_period_lte?: string;
+}): Promise<{ data: unknown; url: string }> {
+  const { data, url } = await callAlphaVantage<Record<string, unknown>>({
+    function: 'BALANCE_SHEET',
+    symbol: params.ticker.toUpperCase(),
+  });
+  const rows = selectReports(data, params.period);
+  const filtered = filterByFiscalDateEnding(rows, {
+    gt: params.report_period_gt,
+    gte: params.report_period_gte,
+    lt: params.report_period_lt,
+    lte: params.report_period_lte,
+  });
+  return { data: filtered.slice(0, params.limit), url };
+}
+
+export async function avCashFlowStatements(params: {
+  ticker: string;
+  period: StatementPeriod;
+  limit: number;
+  report_period_gt?: string;
+  report_period_gte?: string;
+  report_period_lt?: string;
+  report_period_lte?: string;
+}): Promise<{ data: unknown; url: string }> {
+  const { data, url } = await callAlphaVantage<Record<string, unknown>>({
+    function: 'CASH_FLOW',
+    symbol: params.ticker.toUpperCase(),
+  });
+  const rows = selectReports(data, params.period);
+  const filtered = filterByFiscalDateEnding(rows, {
+    gt: params.report_period_gt,
+    gte: params.report_period_gte,
+    lt: params.report_period_lt,
+    lte: params.report_period_lte,
+  });
+  return { data: filtered.slice(0, params.limit), url };
+}
+
+export async function avKeyRatiosSnapshot(ticker: string): Promise<{ data: unknown; url: string }> {
+  // Alpha Vantage doesn't expose a dedicated ratios snapshot; OVERVIEW is the closest.
+  const { data, url } = await avCompanyFacts(ticker);
+  return { data, url };
+}
+

--- a/src/tools/finance/providers/config.ts
+++ b/src/tools/finance/providers/config.ts
@@ -1,0 +1,33 @@
+import type { FinanceDataProviderId } from './types.js';
+
+export type FinanceProviderMode =
+  | { mode: 'auto' }
+  | { mode: 'fixed'; provider: FinanceDataProviderId };
+
+function normalizeProviderId(value: string): FinanceDataProviderId | null {
+  const v = value.trim().toLowerCase();
+  if (!v) return null;
+  if (v === 'financialdatasets' || v === 'financial_datasets' || v === 'financial-datasets') {
+    return 'financialdatasets';
+  }
+  if (v === 'fmp' || v === 'financialmodelingprep' || v === 'financial_modeling_prep') return 'fmp';
+  if (v === 'alphavantage' || v === 'alpha_vantage' || v === 'alpha-vantage') return 'alphavantage';
+  return null;
+}
+
+/**
+ * Select which finance data provider to use.
+ * - Unset or "auto": try providers in fallback order per tool.
+ * - Set to a provider id: only that provider is used.
+ */
+export function getFinanceProviderMode(): FinanceProviderMode {
+  const raw = process.env.FINANCE_DATA_PROVIDER;
+  if (!raw) return { mode: 'auto' };
+  const trimmed = raw.trim().toLowerCase();
+  if (!trimmed || trimmed === 'auto') return { mode: 'auto' };
+
+  const provider = normalizeProviderId(trimmed);
+  if (!provider) return { mode: 'auto' };
+  return { mode: 'fixed', provider };
+}
+

--- a/src/tools/finance/providers/fallback.ts
+++ b/src/tools/finance/providers/fallback.ts
@@ -1,0 +1,50 @@
+import type { FinanceDataProviderId, FinanceProviderResult } from './types.js';
+import { getFinanceProviderMode } from './config.js';
+
+export interface ProviderAttempt<T> {
+  provider: FinanceDataProviderId;
+  run: () => Promise<Omit<FinanceProviderResult<T>, 'provider'>>;
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+function uniqueProviders(attempts: ProviderAttempt<unknown>[]): FinanceDataProviderId[] {
+  const seen = new Set<FinanceDataProviderId>();
+  const order: FinanceDataProviderId[] = [];
+  for (const a of attempts) {
+    if (!seen.has(a.provider)) {
+      seen.add(a.provider);
+      order.push(a.provider);
+    }
+  }
+  return order;
+}
+
+export async function runFinanceProviderChain<T>(
+  label: string,
+  attempts: ProviderAttempt<T>[]
+): Promise<FinanceProviderResult<T>> {
+  const mode = getFinanceProviderMode();
+  const allowed =
+    mode.mode === 'fixed'
+      ? new Set<FinanceDataProviderId>([mode.provider])
+      : new Set<FinanceDataProviderId>(uniqueProviders(attempts));
+
+  const errors: { provider: FinanceDataProviderId; error: string }[] = [];
+
+  for (const attempt of attempts) {
+    if (!allowed.has(attempt.provider)) continue;
+    try {
+      const result = await attempt.run();
+      return { provider: attempt.provider, ...result };
+    } catch (error) {
+      errors.push({ provider: attempt.provider, error: formatError(error) });
+    }
+  }
+
+  const tried = errors.map((e) => `${e.provider}: ${e.error}`).join(' | ');
+  throw new Error(`[finance] ${label} failed. Tried ${Array.from(allowed).join(', ')}. ${tried}`);
+}

--- a/src/tools/finance/providers/financialdatasets.ts
+++ b/src/tools/finance/providers/financialdatasets.ts
@@ -1,0 +1,64 @@
+import { callApi } from '../api.js';
+
+type QueryParams = Record<string, string | number | string[] | undefined>;
+
+export async function fdPriceSnapshot(ticker: string): Promise<{ data: unknown; url: string }> {
+  const { data, url } = await callApi('/prices/snapshot/', { ticker });
+  return { data: (data as Record<string, unknown>).snapshot ?? {}, url };
+}
+
+export async function fdPrices(params: {
+  ticker: string;
+  interval: string;
+  interval_multiplier: number;
+  start_date: string;
+  end_date: string;
+}, options?: { cacheable?: boolean }): Promise<{ data: unknown; url: string }> {
+  const { data, url } = await callApi('/prices/', params, options);
+  return { data: (data as Record<string, unknown>).prices ?? [], url };
+}
+
+export async function fdCompanyFacts(ticker: string): Promise<{ data: unknown; url: string }> {
+  const { data, url } = await callApi('/company/facts', { ticker });
+  return { data: (data as Record<string, unknown>).company_facts ?? {}, url };
+}
+
+export async function fdNews(params: {
+  ticker: string;
+  start_date?: string;
+  end_date?: string;
+  limit?: number;
+}): Promise<{ data: unknown; url: string }> {
+  const { data, url } = await callApi('/news/', params);
+  return { data: (data as Record<string, unknown>).news ?? [], url };
+}
+
+export async function fdIncomeStatements(params: QueryParams): Promise<{ data: unknown; url: string }> {
+  const { data, url } = await callApi('/financials/income-statements/', params);
+  return { data: (data as Record<string, unknown>).income_statements ?? {}, url };
+}
+
+export async function fdBalanceSheets(params: QueryParams): Promise<{ data: unknown; url: string }> {
+  const { data, url } = await callApi('/financials/balance-sheets/', params);
+  return { data: (data as Record<string, unknown>).balance_sheets ?? {}, url };
+}
+
+export async function fdCashFlowStatements(params: QueryParams): Promise<{ data: unknown; url: string }> {
+  const { data, url } = await callApi('/financials/cash-flow-statements/', params);
+  return { data: (data as Record<string, unknown>).cash_flow_statements ?? {}, url };
+}
+
+export async function fdAllFinancialStatements(params: QueryParams): Promise<{ data: unknown; url: string }> {
+  const { data, url } = await callApi('/financials/', params);
+  return { data: (data as Record<string, unknown>).financials ?? {}, url };
+}
+
+export async function fdKeyRatiosSnapshot(ticker: string): Promise<{ data: unknown; url: string }> {
+  const { data, url } = await callApi('/financial-metrics/snapshot/', { ticker });
+  return { data: (data as Record<string, unknown>).snapshot ?? {}, url };
+}
+
+export async function fdKeyRatios(params: QueryParams): Promise<{ data: unknown; url: string }> {
+  const { data, url } = await callApi('/financial-metrics/', params);
+  return { data: (data as Record<string, unknown>).financial_metrics ?? [], url };
+}

--- a/src/tools/finance/providers/fmp.ts
+++ b/src/tools/finance/providers/fmp.ts
@@ -1,0 +1,372 @@
+import { MissingApiKeyError } from './types.js';
+
+const BASE_URL = 'https://financialmodelingprep.com/stable';
+
+function requireFmpApiKey(): string {
+  const key = process.env.FMP_API_KEY;
+  if (!key || !key.trim() || key.trim().startsWith('your-')) {
+    throw new MissingApiKeyError('FMP_API_KEY');
+  }
+  return key.trim();
+}
+
+function toDateOnly(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  // Common FMP formats: "2025-01-31" or "2025-01-31 16:00:00"
+  const match = value.match(/^(\d{4}-\d{2}-\d{2})/);
+  return match ? match[1] : null;
+}
+
+function withinRange(date: string, start?: string, end?: string): boolean {
+  if (start && date < start) return false;
+  if (end && date > end) return false;
+  return true;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+async function callFmp<T = unknown>(
+  path: string,
+  params: Record<string, string | number | undefined>
+): Promise<{ data: T; url: string }> {
+  const apiKey = requireFmpApiKey();
+  const url = new URL(`${BASE_URL}${path}`);
+  for (const [k, v] of Object.entries(params)) {
+    if (v === undefined || v === null) continue;
+    url.searchParams.set(k, String(v));
+  }
+
+  const response = await fetch(url.toString(), { headers: { apikey: apiKey } });
+  if (!response.ok) {
+    throw new Error(`FMP request failed: ${response.status} ${response.statusText}`);
+  }
+  const data = (await response.json()) as T;
+  return { data, url: url.toString() };
+}
+
+export async function fmpPriceSnapshot(ticker: string): Promise<{ data: unknown; url: string }> {
+  const { data, url } = await callFmp<unknown[]>('/quote', { symbol: ticker.toUpperCase() });
+  const first = Array.isArray(data) ? data[0] : null;
+  return { data: first ?? {}, url };
+}
+
+export async function fmpPricesDaily(params: {
+  ticker: string;
+  start_date: string;
+  end_date: string;
+}): Promise<{ data: unknown; url: string }> {
+  const { data, url } = await callFmp<unknown[]>('/historical-price-eod/full', {
+    symbol: params.ticker.toUpperCase(),
+  });
+
+  const filtered = Array.isArray(data)
+    ? data
+        .map((row) => {
+          if (!row || typeof row !== 'object') return null;
+          const r = row as Record<string, unknown>;
+          const date = toDateOnly(r.date);
+          if (!date) return null;
+          if (!withinRange(date, params.start_date, params.end_date)) return null;
+          return { ...r, date };
+        })
+        .filter(Boolean)
+    : [];
+
+  // Sort ascending by date for consistency with other providers
+  (filtered as Array<Record<string, unknown>>).sort((a, b) =>
+    String(a.date).localeCompare(String(b.date))
+  );
+
+  return { data: filtered, url };
+}
+
+type PriceInterval = 'minute' | 'day' | 'week' | 'month' | 'year';
+
+function parseNumber(value: unknown): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value === 'string') {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function getIsoWeekKey(dateStr: string): string {
+  // ISO week date algorithm using UTC to avoid timezone shifts.
+  const date = new Date(`${dateStr}T00:00:00Z`);
+  const day = date.getUTCDay() || 7; // 1..7 (Mon..Sun)
+  date.setUTCDate(date.getUTCDate() + 4 - day);
+  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+  const week = Math.ceil((((date.getTime() - yearStart.getTime()) / 86400000) + 1) / 7);
+  const year = date.getUTCFullYear();
+  return `${year}-W${String(week).padStart(2, '0')}`;
+}
+
+function aggregateBars(rows: Array<Record<string, unknown>>): Record<string, unknown> {
+  const first = rows[0] ?? {};
+  const last = rows[rows.length - 1] ?? {};
+
+  let high: number | null = null;
+  let low: number | null = null;
+  let volume = 0;
+
+  for (const r of rows) {
+    const h = parseNumber(r.high);
+    const l = parseNumber(r.low);
+    const v = parseNumber(r.volume);
+    if (h !== null) high = high === null ? h : Math.max(high, h);
+    if (l !== null) low = low === null ? l : Math.min(low, l);
+    if (v !== null) volume += v;
+  }
+
+  return {
+    date: last.date ?? first.date,
+    open: first.open,
+    high: high ?? undefined,
+    low: low ?? undefined,
+    close: last.close,
+    volume: volume || undefined,
+  };
+}
+
+function groupConsecutive<T>(items: T[], size: number): T[][] {
+  if (size <= 1) return items.map((i) => [i]);
+  const groups: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    groups.push(items.slice(i, i + size));
+  }
+  return groups;
+}
+
+function resampleDaily(
+  daily: Array<Record<string, unknown>>,
+  interval: Exclude<PriceInterval, 'minute'>,
+  intervalMultiplier: number
+): Array<Record<string, unknown>> {
+  if (interval === 'day') {
+    return groupConsecutive(daily, Math.max(1, intervalMultiplier)).map((g) => aggregateBars(g));
+  }
+
+  const buckets = new Map<string, Array<Record<string, unknown>>>();
+  const bucketOrder: string[] = [];
+
+  const getBucketKey = (date: string): string => {
+    if (interval === 'week') return getIsoWeekKey(date);
+    if (interval === 'month') return date.slice(0, 7); // YYYY-MM
+    return date.slice(0, 4); // YYYY
+  };
+
+  for (const row of daily) {
+    const date = typeof row.date === 'string' ? row.date : null;
+    if (!date) continue;
+    const key = getBucketKey(date);
+    if (!buckets.has(key)) {
+      buckets.set(key, []);
+      bucketOrder.push(key);
+    }
+    buckets.get(key)!.push(row);
+  }
+
+  const bucketBars = bucketOrder
+    .map((k) => buckets.get(k)!)
+    .filter((rows) => rows.length > 0)
+    .map((rows) => aggregateBars(rows));
+
+  // Apply multiplier by grouping consecutive bucket bars.
+  return groupConsecutive(bucketBars, Math.max(1, intervalMultiplier)).map((g) => aggregateBars(g));
+}
+
+export async function fmpPrices(params: {
+  ticker: string;
+  interval: PriceInterval;
+  interval_multiplier: number;
+  start_date: string;
+  end_date: string;
+}): Promise<{ data: unknown; url: string }> {
+  if (params.interval === 'minute') {
+    throw new Error('FMP provider currently supports daily-or-higher intervals only');
+  }
+
+  const { data: dailyData, url } = await fmpPricesDaily({
+    ticker: params.ticker,
+    start_date: params.start_date,
+    end_date: params.end_date,
+  });
+
+  const daily = Array.isArray(dailyData)
+    ? (dailyData.filter((r) => r && typeof r === 'object') as Array<Record<string, unknown>>)
+    : [];
+
+  const resampled = resampleDaily(daily, params.interval, params.interval_multiplier);
+  return { data: resampled, url };
+}
+
+export async function fmpCompanyFacts(ticker: string): Promise<{ data: unknown; url: string }> {
+  const { data, url } = await callFmp<unknown[]>('/profile', { symbol: ticker.toUpperCase() });
+  const first = Array.isArray(data) ? data[0] : null;
+  return { data: first ?? {}, url };
+}
+
+export async function fmpNews(params: {
+  ticker: string;
+  limit?: number;
+  start_date?: string;
+  end_date?: string;
+}): Promise<{ data: unknown; url: string }> {
+  const { data, url } = await callFmp<unknown[]>('/news/stock', {
+    symbols: params.ticker.toUpperCase(),
+    limit: params.limit,
+  });
+
+  const filtered = Array.isArray(data)
+    ? data.filter((row) => {
+        if (!row || typeof row !== 'object') return false;
+        const r = row as Record<string, unknown>;
+        const date = toDateOnly(r.publishedDate);
+        if (!date) return true;
+        return withinRange(date, params.start_date, params.end_date);
+      })
+    : [];
+
+  return { data: filtered, url };
+}
+
+type StatementPeriod = 'annual' | 'quarterly' | 'ttm';
+
+function fmpPeriodParam(period: StatementPeriod): { pathSuffix: string; period?: string } {
+  if (period === 'ttm') return { pathSuffix: '-ttm' };
+  return { pathSuffix: '', period: period === 'quarterly' ? 'quarter' : 'annual' };
+}
+
+function filterByReportPeriod<T extends Record<string, unknown>>(
+  rows: T[],
+  filters: { gt?: string; gte?: string; lt?: string; lte?: string }
+): T[] {
+  const { gt, gte, lt, lte } = filters;
+  return rows.filter((row) => {
+    const date = toDateOnly(row.date);
+    if (!date) return true;
+    if (gt && !(date > gt)) return false;
+    if (gte && !(date >= gte)) return false;
+    if (lt && !(date < lt)) return false;
+    if (lte && !(date <= lte)) return false;
+    return true;
+  });
+}
+
+export async function fmpIncomeStatements(params: {
+  ticker: string;
+  period: StatementPeriod;
+  limit: number;
+  report_period_gt?: string;
+  report_period_gte?: string;
+  report_period_lt?: string;
+  report_period_lte?: string;
+}): Promise<{ data: unknown; url: string }> {
+  const { pathSuffix, period } = fmpPeriodParam(params.period);
+  const { data, url } = await callFmp<unknown[]>(`/income-statement${pathSuffix}`, {
+    symbol: params.ticker.toUpperCase(),
+    period,
+    limit: params.limit,
+  });
+
+  const rows = Array.isArray(data) ? data.filter(isRecord) : [];
+  const filtered = filterByReportPeriod(rows, {
+    gt: params.report_period_gt,
+    gte: params.report_period_gte,
+    lt: params.report_period_lt,
+    lte: params.report_period_lte,
+  });
+  return { data: filtered, url };
+}
+
+export async function fmpBalanceSheets(params: {
+  ticker: string;
+  period: StatementPeriod;
+  limit: number;
+  report_period_gt?: string;
+  report_period_gte?: string;
+  report_period_lt?: string;
+  report_period_lte?: string;
+}): Promise<{ data: unknown; url: string }> {
+  const { pathSuffix, period } = fmpPeriodParam(params.period);
+  const { data, url } = await callFmp<unknown[]>(`/balance-sheet-statement${pathSuffix}`, {
+    symbol: params.ticker.toUpperCase(),
+    period,
+    limit: params.limit,
+  });
+
+  const rows = Array.isArray(data) ? data.filter(isRecord) : [];
+  const filtered = filterByReportPeriod(rows, {
+    gt: params.report_period_gt,
+    gte: params.report_period_gte,
+    lt: params.report_period_lt,
+    lte: params.report_period_lte,
+  });
+  return { data: filtered, url };
+}
+
+export async function fmpCashFlowStatements(params: {
+  ticker: string;
+  period: StatementPeriod;
+  limit: number;
+  report_period_gt?: string;
+  report_period_gte?: string;
+  report_period_lt?: string;
+  report_period_lte?: string;
+}): Promise<{ data: unknown; url: string }> {
+  const { pathSuffix, period } = fmpPeriodParam(params.period);
+  const { data, url } = await callFmp<unknown[]>(`/cash-flow-statement${pathSuffix}`, {
+    symbol: params.ticker.toUpperCase(),
+    period,
+    limit: params.limit,
+  });
+
+  const rows = Array.isArray(data) ? data.filter(isRecord) : [];
+  const filtered = filterByReportPeriod(rows, {
+    gt: params.report_period_gt,
+    gte: params.report_period_gte,
+    lt: params.report_period_lt,
+    lte: params.report_period_lte,
+  });
+  return { data: filtered, url };
+}
+
+export async function fmpKeyMetricsSnapshot(ticker: string): Promise<{ data: unknown; url: string }> {
+  const { data, url } = await callFmp<unknown[]>('/key-metrics-ttm', { symbol: ticker.toUpperCase() });
+  const first = Array.isArray(data) ? data[0] : null;
+  return { data: first ?? {}, url };
+}
+
+export async function fmpKeyMetrics(params: {
+  ticker: string;
+  period: 'annual' | 'quarterly' | 'ttm';
+  limit: number;
+  report_period_gt?: string;
+  report_period_gte?: string;
+  report_period_lt?: string;
+  report_period_lte?: string;
+}): Promise<{ data: unknown; url: string }> {
+  if (params.period === 'ttm') {
+    const { data, url } = await callFmp<unknown[]>('/key-metrics-ttm', { symbol: params.ticker.toUpperCase() });
+    const first = Array.isArray(data) ? data[0] : null;
+    return { data: first ? [first] : [], url };
+  }
+
+  const { data, url } = await callFmp<unknown[]>('/key-metrics', {
+    symbol: params.ticker.toUpperCase(),
+    period: params.period === 'quarterly' ? 'quarter' : 'annual',
+    limit: params.limit,
+  });
+
+  const rows = Array.isArray(data) ? data.filter(isRecord) : [];
+  const filtered = filterByReportPeriod(rows, {
+    gt: params.report_period_gt,
+    gte: params.report_period_gte,
+    lt: params.report_period_lt,
+    lte: params.report_period_lte,
+  });
+  return { data: filtered, url };
+}

--- a/src/tools/finance/providers/types.ts
+++ b/src/tools/finance/providers/types.ts
@@ -1,0 +1,15 @@
+export type FinanceDataProviderId = 'financialdatasets' | 'fmp' | 'alphavantage';
+
+export interface FinanceProviderResult<T> {
+  provider: FinanceDataProviderId;
+  data: T;
+  /** Public URLs safe to show to the model/user (no API keys). */
+  sourceUrls: string[];
+}
+
+export class MissingApiKeyError extends Error {
+  readonly name = 'MissingApiKeyError';
+  constructor(public readonly envVar: string) {
+    super(`Missing required environment variable: ${envVar}`);
+  }
+}


### PR DESCRIPTION
## Summary
Adds a finance data provider abstraction with env-driven provider selection and fallback across multiple vendors.

### What changed
- Added provider layer under `src/tools/finance/providers/`:
  - `config.ts` for `FINANCE_DATA_PROVIDER` mode (`auto|financialdatasets|fmp|alphavantage`)
  - `fallback.ts` for provider-chain execution
  - provider clients: `financialdatasets.ts`, `fmp.ts`, `alphavantage.ts`
- Wired fallback logic into core finance tools:
  - `get_price_snapshot`, `get_prices`
  - `get_company_facts`
  - `get_news`
  - `get_income_statements`, `get_balance_sheets`, `get_cash_flow_statements`, `get_all_financial_statements`
  - `get_key_ratios_snapshot`, `get_key_ratios`
- Kept source URLs safe for model output (redacted API keys where needed)
- Updated config/docs:
  - `env.example` with new finance provider vars
  - `README.md` prerequisites and `.env` setup examples

## Notes
- Existing Financial Datasets-only tools not targeted in this change remain unchanged (e.g. filings, insider trades, analyst estimates, crypto).

## Validation
- `bun run typecheck`
- `bun test`
