### PR TITLE
Fix issue 100 : Add API source to error messages

### DIFF
--- a/src/model/llm.ts
+++ b/src/model/llm.ts
@@ -53,7 +53,7 @@ type ModelFactory = (name: string, opts: ModelOpts) => BaseChatModel;
 function getApiKey(envVar: string): string {
   const apiKey = process.env[envVar];
   if (!apiKey) {
-    throw new Error(`${envVar} not found in environment variables`);
+    throw new Error(`[LLM] ${envVar} not found in environment variables`);
   }
   return apiKey;
 }

--- a/src/tools/fetch/web-fetch.ts
+++ b/src/tools/fetch/web-fetch.ts
@@ -190,10 +190,10 @@ async function fetchWithRedirects(params: {
     try {
       parsedUrl = new URL(currentUrl);
     } catch {
-      throw new Error("Invalid URL: must be http or https");
+      throw new Error("[Web Fetch] Invalid URL: must be http or https");
     }
     if (!["http:", "https:"].includes(parsedUrl.protocol)) {
-      throw new Error("Invalid URL: must be http or https");
+      throw new Error("[Web Fetch] Invalid URL: must be http or https");
     }
 
     const response = await fetch(parsedUrl.toString(), {
@@ -205,15 +205,15 @@ async function fetchWithRedirects(params: {
     if (isRedirectStatus(response.status)) {
       const location = response.headers.get("location");
       if (!location) {
-        throw new Error(`Redirect missing location header (${response.status})`);
+        throw new Error(`[Web Fetch] Redirect missing location header (${response.status})`);
       }
       redirectCount += 1;
       if (redirectCount > params.maxRedirects) {
-        throw new Error(`Too many redirects (limit: ${params.maxRedirects})`);
+        throw new Error(`[Web Fetch] Too many redirects (limit: ${params.maxRedirects})`);
       }
       const nextUrl = new URL(location, parsedUrl).toString();
       if (visited.has(nextUrl)) {
-        throw new Error("Redirect loop detected");
+        throw new Error("[Web Fetch] Redirect loop detected");
       }
       visited.add(nextUrl);
       currentUrl = nextUrl;
@@ -249,10 +249,10 @@ async function runWebFetch(params: {
   try {
     parsedUrl = new URL(params.url);
   } catch {
-    throw new Error("Invalid URL: must be http or https");
+    throw new Error("[Web Fetch] Invalid URL: must be http or https");
   }
   if (!["http:", "https:"].includes(parsedUrl.protocol)) {
-    throw new Error("Invalid URL: must be http or https");
+    throw new Error("[Web Fetch] Invalid URL: must be http or https");
   }
 
   const start = Date.now();
@@ -275,7 +275,7 @@ async function runWebFetch(params: {
       maxChars: DEFAULT_ERROR_MAX_CHARS,
     });
     const wrappedDetail = wrapWebFetchContent(detail || res.statusText, DEFAULT_ERROR_MAX_CHARS);
-    throw new Error(`Web fetch failed (${res.status}): ${wrappedDetail.text}`);
+    throw new Error(`[Web Fetch] failed (${res.status}): ${wrappedDetail.text}`);
   }
 
   const contentType = res.headers.get("content-type") ?? "application/octet-stream";

--- a/src/tools/finance/filings.ts
+++ b/src/tools/finance/filings.ts
@@ -21,7 +21,7 @@ export interface FilingItemTypes {
 export async function getFilingItemTypes(): Promise<FilingItemTypes> {
   const response = await fetch('https://api.financialdatasets.ai/filings/items/types/');
   if (!response.ok) {
-    throw new Error(`Failed to fetch filing item types: ${response.status}`);
+    throw new Error(`[Financial Datasets API] Failed to fetch filing item types: ${response.status}`);
   }
   return response.json();
 }

--- a/src/tools/search/perplexity.ts
+++ b/src/tools/search/perplexity.ts
@@ -24,7 +24,7 @@ interface PerplexityCompletionResponse {
 async function callPerplexity(query: string): Promise<PerplexityCompletionResponse> {
   const apiKey = process.env.PERPLEXITY_API_KEY;
   if (!apiKey) {
-    throw new Error('PERPLEXITY_API_KEY is not set');
+    throw new Error('[Perplexity API] PERPLEXITY_API_KEY is not set');
   }
 
   const response = await fetch(PERPLEXITY_API_URL, {
@@ -42,7 +42,7 @@ async function callPerplexity(query: string): Promise<PerplexityCompletionRespon
 
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(`Perplexity API ${response.status}: ${text}`);
+    throw new Error(`[Perplexity API] ${response.status}: ${text}`);
   }
 
   return response.json() as Promise<PerplexityCompletionResponse>;


### PR DESCRIPTION
This fixes issue 100.

Some error messages did not mention which API they came from, which made debugging confusing.

I added the API name to those error messages in a few files where it was missing:

filings.ts
perplexity.ts
web-fetch.ts
llm.ts

These are only text changes to error messages. No logic was changed.

I also ran npx tsc --noEmit and there were no type errors.