### PR TITLE
Add GroqCloud provider support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@
 - Install deps: `bun install`
 - Run: `bun run start` or `bun run src/index.tsx`
 - Dev (watch mode): `bun run dev`
+- Build: `bun run build`
+- Lint: `bun run lint`
 - Type-check: `bun run typecheck`
 - Tests: `bun test`
 - Evals: `bun run src/evals/run.ts` (full) or `bun run src/evals/run.ts --sample 10` (sampled)
@@ -45,9 +47,9 @@
 
 ## LLM Providers
 
-- Supported: OpenAI (default), Anthropic, Google, xAI (Grok), OpenRouter, Ollama (local).
-- Default model: `gpt-5.2`. Provider detection is prefix-based (`claude-` -> Anthropic, `gemini-` -> Google, etc.).
-- Fast models for lightweight tasks: see `FAST_MODELS` map in `src/model/llm.ts`.
+- Supported: OpenAI (default), Anthropic, Google, xAI (Grok), GroqCloud, Moonshot, DeepSeek, OpenRouter, Ollama (local).
+- Default model: `gpt-5.2`. Provider detection is prefix-based (`claude-` -> Anthropic, `gemini-` -> Google, `grok-` -> xAI, `groq:` -> GroqCloud, `openrouter:` -> OpenRouter, `ollama:` -> Ollama, etc.).
+- Fast models for lightweight tasks: configured per provider via `fastModel` in `src/providers.ts` (used by `getFastModel()` in `src/model/llm.ts`).
 - Anthropic uses explicit `cache_control` on system prompt for prompt caching cost savings.
 - Users switch providers/models via `/model` command in the CLI.
 
@@ -78,7 +80,7 @@
 
 ## Environment Variables
 
-- LLM keys: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `XAI_API_KEY`, `OPENROUTER_API_KEY`
+- LLM keys: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `XAI_API_KEY`, `GROQ_API_KEY`, `MOONSHOT_API_KEY`, `DEEPSEEK_API_KEY`, `OPENROUTER_API_KEY`
 - Ollama: `OLLAMA_BASE_URL` (default `http://127.0.0.1:11434`)
 - Finance: `FINANCIAL_DATASETS_API_KEY`
 - Search: `EXASEARCH_API_KEY` (preferred), `TAVILY_API_KEY` (fallback)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Dexter takes complex financial questions and turns them into clear, step-by-step
 ## ✅ Prerequisites
 
 - [Bun](https://bun.com) runtime (v1.0 or higher)
-- OpenAI API key (get [here](https://platform.openai.com/api-keys))
+- At least one supported LLM API key (OpenAI default; GroqCloud optional)
 - Financial Datasets API key (get [here](https://financialdatasets.ai))
 - Exa API key (get [here](https://exa.ai)) - optional, for web search
 
@@ -81,6 +81,7 @@ cp env.example .env
 # ANTHROPIC_API_KEY=your-anthropic-api-key (optional)
 # GOOGLE_API_KEY=your-google-api-key (optional)
 # XAI_API_KEY=your-xai-api-key (optional)
+# GROQ_API_KEY=your-groq-api-key (optional)
 # OPENROUTER_API_KEY=your-openrouter-api-key (optional)
 
 # Institutional-grade market data for agents; AAPL, NVDA, MSFT are free
@@ -93,6 +94,8 @@ cp env.example .env
 # EXASEARCH_API_KEY=your-exa-api-key
 # TAVILY_API_KEY=your-tavily-api-key
 ```
+
+**Note**: GroqCloud uses an OpenAI-compatible Chat Completions API. You can switch providers/models anytime via `/model` inside the CLI.
 
 ## 🚀 How to Run
 

--- a/env.example
+++ b/env.example
@@ -3,6 +3,7 @@ OPENAI_API_KEY=your-api-key
 ANTHROPIC_API_KEY=your-api-key
 GOOGLE_API_KEY=your-api-key
 XAI_API_KEY=your-api-key
+GROQ_API_KEY=your-api-key
 OPENROUTER_API_KEY=your-api-key
 MOONSHOT_API_KEY=your-api-key
 DEEPSEEK_API_KEY=your-api-key

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "scripts": {
     "start": "bun run src/index.tsx",
     "dev": "bun --watch run src/index.tsx",
+    "build": "bun build --target=bun --packages=external --outdir dist src/index.tsx",
+    "lint": "bun run typecheck",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
     "test:watch": "bun test --watch",

--- a/src/components/ModelSelector.tsx
+++ b/src/components/ModelSelector.tsx
@@ -32,6 +32,12 @@ const PROVIDER_MODELS: Record<string, Model[]> = {
     { id: 'grok-4-0709', displayName: 'Grok 4' },
     { id: 'grok-4-1-fast-reasoning', displayName: 'Grok 4.1 Fast Reasoning' },
   ],
+  groq: [
+    { id: 'groq:llama-3.1-8b-instant', displayName: 'Llama 3.1 8B (Instant)' },
+    { id: 'groq:llama-3.3-70b-versatile', displayName: 'Llama 3.3 70B (Versatile)' },
+    { id: 'groq:openai/gpt-oss-20b', displayName: 'GPT OSS 20B' },
+    { id: 'groq:openai/gpt-oss-120b', displayName: 'GPT OSS 120B' },
+  ],
   moonshot: [
     { id: 'kimi-k2-5', displayName: 'Kimi K2.5' },
   ],
@@ -64,7 +70,7 @@ export function getDefaultModelForProvider(providerId: string): string | undefin
 
 export function getModelDisplayName(modelId: string): string {
   // Handle prefixed model IDs (e.g., "ollama:llama3", "openrouter:anthropic/claude-3.5")
-  const normalizedId = modelId.replace(/^(ollama|openrouter):/, '');
+  const normalizedId = modelId.replace(/^(ollama|openrouter|groq):/, '');
   
   // Search through all providers for the model
   for (const provider of PROVIDERS) {

--- a/src/model/llm.ts
+++ b/src/model/llm.ts
@@ -81,6 +81,15 @@ const MODEL_FACTORIES: Record<string, ModelFactory> = {
         baseURL: 'https://api.x.ai/v1',
       },
     }),
+  groq: (name, opts) =>
+    new ChatOpenAI({
+      model: name.replace(/^groq:/, ''),
+      ...opts,
+      apiKey: getApiKey('GROQ_API_KEY'),
+      configuration: {
+        baseURL: 'https://api.groq.com/openai/v1',
+      },
+    }),
   openrouter: (name, opts) =>
     new ChatOpenAI({
       model: name.replace(/^openrouter:/, ''),

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -46,6 +46,13 @@ export const PROVIDERS: ProviderDef[] = [
     fastModel: 'grok-4-1-fast-reasoning',
   },
   {
+    id: 'groq',
+    displayName: 'GroqCloud',
+    modelPrefix: 'groq:',
+    apiKeyEnvVar: 'GROQ_API_KEY',
+    fastModel: 'groq:llama-3.1-8b-instant',
+  },
+  {
     id: 'moonshot',
     displayName: 'Moonshot',
     modelPrefix: 'kimi-',


### PR DESCRIPTION
## Summary

Adds GroqCloud as a first-class LLM provider option in Dexter (OpenAI-compatible Chat Completions), including provider routing, model selection UI entries, and env/docs updates.

## Changes

### Provider registry + routing
- Added `groq` to the canonical provider registry (`src/providers.ts`) with:
  - `modelPrefix`: `groq:`
  - `apiKeyEnvVar`: `GROQ_API_KEY`
  - `fastModel`: `groq:llama-3.1-8b-instant`
- Implemented GroqCloud model factory in `src/model/llm.ts` using LangChain's `ChatOpenAI` against Groq's OpenAI-compatible base URL (`https://api.groq.com/openai/v1`).
  - Stored model IDs keep the `groq:` prefix for routing; the prefix is stripped before sending to Groq (`groq:llama-...` → `llama-...`).

### CLI model selection
- Added GroqCloud preset model entries in `src/components/ModelSelector.tsx` (prefixed with `groq:`) so users can select Groq models from the built-in list.
- Updated model display-name normalization to also handle `groq:`-prefixed model IDs.

### Environment + docs
- Added `GROQ_API_KEY` to `env.example`.
- Updated `README.md` prerequisites and `.env` example snippet to mention GroqCloud and the `GROQ_API_KEY`.
- Updated `AGENTS.md` provider list / env var list to include GroqCloud and added `build`/`lint` commands for local workflows.

### Tooling scripts
- Added `bun run build` (bundles to `dist/` with external packages) and `bun run lint` (alias to `typecheck`) in `package.json`.

## How to test

- `bun run build`
- `bun run lint`
- `bun run typecheck`
- `bun test`

## Notes

GroqCloud is wired via the OpenAI-compatible Chat Completions API (base URL `https://api.groq.com/openai/v1`), so it integrates cleanly via `ChatOpenAI` while keeping the provider routing model-prefix approach consistent with existing providers.