### PR TITLE
Add institutional ownership tools with investor name resolution

### DIFF
--- a/src/tools/finance/api.ts
+++ b/src/tools/finance/api.ts
@@ -3,6 +3,26 @@ import { logger } from '../../utils/logger.js';
 
 const BASE_URL = 'https://api.financialdatasets.ai';
 
+// Lazy-loaded, in-memory cache for the investor list (~10k names, ~200KB).
+// Fetched once per session on first institutional-ownership-by-investor query.
+let _investorList: string[] | null = null;
+
+export async function getInvestorList(): Promise<string[]> {
+  if (_investorList) return _investorList;
+  const url = `${BASE_URL}/institutional-ownership/investors/`;
+  try {
+    const response = await fetch(url, {
+      headers: { 'x-api-key': process.env.FINANCIAL_DATASETS_API_KEY || '' },
+    });
+    if (!response.ok) return [];
+    const data = await response.json();
+    _investorList = (data.investors as string[]) || [];
+    return _investorList;
+  } catch {
+    return [];
+  }
+}
+
 export interface ApiResponse {
   data: Record<string, unknown>;
   url: string;

--- a/src/tools/finance/financial-search.ts
+++ b/src/tools/finance/financial-search.ts
@@ -20,6 +20,7 @@ import { getAnalystEstimates } from './estimates.js';
 import { getSegmentedRevenues } from './segments.js';
 import { getCryptoPriceSnapshot, getCryptoPrices, getCryptoTickers } from './crypto.js';
 import { getInsiderTrades } from './insider_trades.js';
+import { getInstitutionalOwnershipByTicker, getInstitutionalOwnershipByInvestor } from './institutional-ownership.js';
 import { getCompanyFacts } from './company_facts.js';
 
 // All finance tools available for routing
@@ -42,6 +43,8 @@ const FINANCE_TOOLS: StructuredToolInterface[] = [
   // Other Data
   getNews,
   getInsiderTrades,
+  getInstitutionalOwnershipByTicker,
+  getInstitutionalOwnershipByInvestor,
   getSegmentedRevenues,
   getCompanyFacts,
 ];
@@ -77,7 +80,13 @@ Given a user's natural language query about financial data, call the appropriate
    - For cash flow, free cash flow → get_cash_flow_statements
    - For comprehensive analysis → get_all_financial_statements
 
-4. **Efficiency**:
+4. **Institutional Ownership (13-F)**:
+   - "Who owns AAPL?" or "top holders of Tesla" → get_institutional_ownership_by_ticker
+   - "What does Berkshire own?" or "Bridgewater portfolio" → get_institutional_ownership_by_investor
+   - For investor queries, pass the investor name in plain English (e.g. "Scion Asset Management", "Berkshire Hathaway") — the tool resolves it to the API format automatically. Do NOT try to format or uppercase the name yourself.
+   - These use SEC Form 13-F data (quarterly, 45-day lag from quarter end)
+
+5. **Efficiency**:
    - Prefer specific tools over general ones when possible
    - Use get_all_financial_statements only when multiple statement types needed
    - For comparisons between companies, call the same tool for each ticker
@@ -104,6 +113,7 @@ export function createFinancialSearch(model: string): DynamicStructuredTool {
 - Analyst estimates and price targets
 - Company news
 - Insider trading activity
+- Institutional ownership / 13-F holdings (by ticker or by investor)
 - Cryptocurrency prices`,
     schema: FinancialSearchInputSchema,
     func: async (input, _runManager, config?: RunnableConfig) => {

--- a/src/tools/finance/index.ts
+++ b/src/tools/finance/index.ts
@@ -7,6 +7,7 @@ export { getAnalystEstimates } from './estimates.js';
 export { getSegmentedRevenues } from './segments.js';
 export { getCryptoPriceSnapshot, getCryptoPrices, getCryptoTickers } from './crypto.js';
 export { getInsiderTrades } from './insider_trades.js';
+export { getInstitutionalOwnershipByTicker, getInstitutionalOwnershipByInvestor } from './institutional-ownership.js';
 export { getCompanyFacts } from './company_facts.js';
 export { createFinancialSearch } from './financial-search.js';
 export { createFinancialMetrics } from './financial-metrics.js';

--- a/src/tools/finance/institutional-ownership.ts
+++ b/src/tools/finance/institutional-ownership.ts
@@ -1,0 +1,156 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+import { callApi, getInvestorList } from './api.js';
+import { formatToolResult } from '../types.js';
+
+// ---------------------------------------------------------------------------
+// By Ticker — "Who are Apple's top institutional holders?"
+// ---------------------------------------------------------------------------
+
+const ByTickerInputSchema = z.object({
+  ticker: z
+    .string()
+    .describe("The stock ticker symbol. For example, 'AAPL' for Apple."),
+  limit: z
+    .number()
+    .default(10)
+    .describe('Maximum number of holdings to return (default: 10).'),
+  report_period: z
+    .string()
+    .optional()
+    .describe('Exact report period date to filter by (YYYY-MM-DD).'),
+  report_period_gte: z
+    .string()
+    .optional()
+    .describe('Filter for report period greater than or equal to this date (YYYY-MM-DD).'),
+  report_period_lte: z
+    .string()
+    .optional()
+    .describe('Filter for report period less than or equal to this date (YYYY-MM-DD).'),
+  report_period_gt: z
+    .string()
+    .optional()
+    .describe('Filter for report period greater than this date (YYYY-MM-DD).'),
+  report_period_lt: z
+    .string()
+    .optional()
+    .describe('Filter for report period less than this date (YYYY-MM-DD).'),
+});
+
+export const getInstitutionalOwnershipByTicker = new DynamicStructuredTool({
+  name: 'get_institutional_ownership_by_ticker',
+  description:
+    `Retrieves institutional ownership data for a given stock ticker from SEC 13-F filings. ` +
+    `Shows which institutional investors (hedge funds, mutual funds, pension funds) hold shares ` +
+    `of a company, including share quantities, estimated holding prices, and market values. ` +
+    `Use report_period filters to narrow results to a specific quarter.`,
+  schema: ByTickerInputSchema,
+  func: async (input) => {
+    const params: Record<string, string | number | undefined> = {
+      ticker: input.ticker.toUpperCase(),
+      limit: input.limit,
+      report_period: input.report_period,
+      report_period_gte: input.report_period_gte,
+      report_period_lte: input.report_period_lte,
+      report_period_gt: input.report_period_gt,
+      report_period_lt: input.report_period_lt,
+    };
+    const { data, url } = await callApi('/institutional-ownership/', params, { cacheable: true });
+    return formatToolResult(data['institutional-ownership'] || data.institutional_ownership || [], [url]);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Investor name resolution — normalize user input to API format
+// ---------------------------------------------------------------------------
+
+async function resolveInvestorName(name: string): Promise<string> {
+  const investors = await getInvestorList();
+  if (investors.length === 0) return name; // API unavailable, pass through
+
+  // Normalize: uppercase, replace punctuation/spaces with underscores, collapse/trim
+  const normalized = name
+    .toUpperCase()
+    .replace(/[.\-,&'/()]+/g, '_')
+    .replace(/\s+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_|_$/g, '');
+
+  // Exact match
+  if (investors.includes(normalized)) return normalized;
+
+  // Try common suffixes
+  for (const suffix of ['_LLC', '_INC', '_LP', '_LTD', '_CO', '_CORP']) {
+    const withSuffix = normalized + suffix;
+    if (investors.includes(withSuffix)) return withSuffix;
+  }
+
+  // Substring match: find investors that contain the normalized name
+  const matches = investors.filter(inv => inv.includes(normalized));
+  if (matches.length === 1) return matches[0]; // unambiguous match
+  if (matches.length > 1) {
+    // Prefer shortest match (most specific)
+    return matches.sort((a, b) => a.length - b.length)[0];
+  }
+
+  // No match found — pass through and let API return the error
+  return name;
+}
+
+// ---------------------------------------------------------------------------
+// By Investor — "What does Berkshire Hathaway own?"
+// ---------------------------------------------------------------------------
+
+const ByInvestorInputSchema = z.object({
+  investor: z
+    .string()
+    .describe("The name of the institutional investor. For example, 'Berkshire Hathaway' or 'Bridgewater Associates'."),
+  limit: z
+    .number()
+    .default(10)
+    .describe('Maximum number of holdings to return (default: 10).'),
+  report_period: z
+    .string()
+    .optional()
+    .describe('Exact report period date to filter by (YYYY-MM-DD).'),
+  report_period_gte: z
+    .string()
+    .optional()
+    .describe('Filter for report period greater than or equal to this date (YYYY-MM-DD).'),
+  report_period_lte: z
+    .string()
+    .optional()
+    .describe('Filter for report period less than or equal to this date (YYYY-MM-DD).'),
+  report_period_gt: z
+    .string()
+    .optional()
+    .describe('Filter for report period greater than this date (YYYY-MM-DD).'),
+  report_period_lt: z
+    .string()
+    .optional()
+    .describe('Filter for report period less than this date (YYYY-MM-DD).'),
+});
+
+export const getInstitutionalOwnershipByInvestor = new DynamicStructuredTool({
+  name: 'get_institutional_ownership_by_investor',
+  description:
+    `Retrieves the portfolio holdings of a specific institutional investor from SEC 13-F filings. ` +
+    `Shows which stocks an investment manager holds, including tickers, share quantities, ` +
+    `estimated holding prices, and market values. Covers investment managers with $100M+ in assets. ` +
+    `Use report_period filters to narrow results to a specific quarter.`,
+  schema: ByInvestorInputSchema,
+  func: async (input) => {
+    const resolvedInvestor = await resolveInvestorName(input.investor);
+    const params: Record<string, string | number | undefined> = {
+      investor: resolvedInvestor,
+      limit: input.limit,
+      report_period: input.report_period,
+      report_period_gte: input.report_period_gte,
+      report_period_lte: input.report_period_lte,
+      report_period_gt: input.report_period_gt,
+      report_period_lt: input.report_period_lt,
+    };
+    const { data, url } = await callApi('/institutional-ownership/', params, { cacheable: true });
+    return formatToolResult(data['institutional-ownership'] || data.institutional_ownership || [], [url]);
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `get_institutional_ownership_by_ticker` and `get_institutional_ownership_by_investor` tools backed by SEC 13-F data
- Investor names are automatically resolved from natural language (e.g. "Scion Asset Management") to the API's `UPPERCASE_WITH_UNDERSCORES` format via a cached investor list + fuzzy matching (exact → suffix → substring, preferring shortest match)
- Registers both tools in the `financial_search` router with prompt guidance so the LLM passes plain-English investor names and lets the tool handle resolution

## Details

**4 files changed:**

| File | Change |
|---|---|
| `src/tools/finance/api.ts` | Added `getInvestorList()` — lazy in-memory cache of ~10k investor names from `/institutional-ownership/investors/` |
| `src/tools/finance/institutional-ownership.ts` | New file — both tools + `resolveInvestorName()` (normalize → exact → suffix → substring matching) |
| `src/tools/finance/financial-search.ts` | Import, router entries, section 4 prompt guidance, description update |
| `src/tools/finance/index.ts` | Re-export the new tools |

**Name resolution strategy:**
1. Normalize input to `UPPERCASE_WITH_UNDERSCORES`
2. Exact match against investor list
3. Try common suffixes (`_LLC`, `_INC`, `_LP`, etc.)
4. Substring match (prefer shortest/most-specific)
5. Pass through on no match (let API return error)

## Test plan

- [ ] `bun run typecheck` passes
- [ ] `bun test` — existing tests unaffected
- [ ] Manual: "Who owns AAPL?" routes to `get_institutional_ownership_by_ticker`
- [ ] Manual: "What does Berkshire Hathaway own?" resolves to `BERKSHIRE_HATHAWAY_INC` and returns holdings