### PR TITLE
Use fast model for sub-agent LLM calls

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -46,8 +46,9 @@ export class Agent {
    */
   static create(config: AgentConfig = {}): Agent {
     const model = config.model ?? DEFAULT_MODEL;
-    const tools = getTools(model);
-    const systemPrompt = buildSystemPrompt(model);
+    const modelProvider = config.modelProvider ?? 'openai';
+    const tools = getTools(model, modelProvider);
+    const systemPrompt = buildSystemPrompt(model, modelProvider);
     return new Agent(config, tools, systemPrompt);
   }
 

--- a/src/agent/prompts.ts
+++ b/src/agent/prompts.ts
@@ -97,8 +97,8 @@ Keep tables compact:
  * Build the system prompt for the agent.
  * @param model - The model name (used to get appropriate tool descriptions)
  */
-export function buildSystemPrompt(model: string): string {
-  const toolDescriptions = buildToolDescriptions(model);
+export function buildSystemPrompt(model: string, modelProvider: string = 'openai'): string {
+  const toolDescriptions = buildToolDescriptions(model, modelProvider);
 
   return `You are Dexter, a CLI assistant with access to research tools.
 

--- a/src/hooks/useModelSelection.ts
+++ b/src/hooks/useModelSelection.ts
@@ -73,7 +73,7 @@ export function useModelSelection(
   const [pendingSelectedModelId, setPendingSelectedModelId] = useState<string | null>(null);
   
   // Message history ref - shared with agent runner
-  const inMemoryChatHistoryRef = useRef<InMemoryChatHistory>(new InMemoryChatHistory(model));
+  const inMemoryChatHistoryRef = useRef<InMemoryChatHistory>(new InMemoryChatHistory(model, provider));
   
   // Helper to complete a model switch (DRY pattern)
   const completeModelSwitch = useCallback((newProvider: string, newModelId: string) => {
@@ -81,7 +81,7 @@ export function useModelSelection(
     setModel(newModelId);
     setSetting('provider', newProvider);
     setSetting('modelId', newModelId);
-    inMemoryChatHistoryRef.current.setModel(newModelId);
+    inMemoryChatHistoryRef.current.setModel(newModelId, newProvider);
     setPendingProvider(null);
     setPendingModels([]);
     setPendingSelectedModelId(null);

--- a/src/tools/finance/financial-metrics.ts
+++ b/src/tools/finance/financial-metrics.ts
@@ -2,7 +2,7 @@ import { DynamicStructuredTool, StructuredToolInterface } from '@langchain/core/
 import type { RunnableConfig } from '@langchain/core/runnables';
 import { AIMessage, ToolCall } from '@langchain/core/messages';
 import { z } from 'zod';
-import { callLlm } from '../../model/llm.js';
+import { callLlm, getFastModel } from '../../model/llm.js';
 import { formatToolResult } from '../types.js';
 import { getCurrentDate } from '../../agent/prompts.js';
 
@@ -79,7 +79,7 @@ const FinancialMetricsInputSchema = z.object({
  * Create a financial_metrics tool configured with the specified model.
  * Uses native LLM tool calling for routing queries to fundamental analysis tools.
  */
-export function createFinancialMetrics(model: string): DynamicStructuredTool {
+export function createFinancialMetrics(model: string, modelProvider: string = 'openai'): DynamicStructuredTool {
   return new DynamicStructuredTool({
     name: 'financial_metrics',
     description: `Intelligent agentic search for fundamental analysis. Takes a natural language query and automatically routes to financial statements and key ratios tools. Use for:
@@ -96,7 +96,7 @@ export function createFinancialMetrics(model: string): DynamicStructuredTool {
       // 1. Call LLM with metrics tools bound (native tool calling)
       onProgress?.('Searching...');
       const { response } = await callLlm(input.query, {
-        model,
+        model: getFastModel(modelProvider, model),
         systemPrompt: buildRouterPrompt(),
         tools: METRICS_TOOLS,
       });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -26,7 +26,7 @@ export interface RegisteredTool {
  * @param model - The model name (needed for tools that require model-specific configuration)
  * @returns Array of registered tools
  */
-export function getToolRegistry(model: string): RegisteredTool[] {
+export function getToolRegistry(model: string, modelProvider: string = 'openai'): RegisteredTool[] {
   const tools: RegisteredTool[] = [
     {
       name: 'financial_search',
@@ -35,12 +35,12 @@ export function getToolRegistry(model: string): RegisteredTool[] {
     },
     {
       name: 'financial_metrics',
-      tool: createFinancialMetrics(model),
+      tool: createFinancialMetrics(model, modelProvider),
       description: FINANCIAL_METRICS_DESCRIPTION,
     },
     {
       name: 'read_filings',
-      tool: createReadFilings(model),
+      tool: createReadFilings(model, modelProvider),
       description: READ_FILINGS_DESCRIPTION,
     },
     {
@@ -95,8 +95,8 @@ export function getToolRegistry(model: string): RegisteredTool[] {
  * @param model - The model name
  * @returns Array of tool instances
  */
-export function getTools(model: string): StructuredToolInterface[] {
-  return getToolRegistry(model).map((t) => t.tool);
+export function getTools(model: string, modelProvider: string = 'openai'): StructuredToolInterface[] {
+  return getToolRegistry(model, modelProvider).map((t) => t.tool);
 }
 
 /**
@@ -106,8 +106,8 @@ export function getTools(model: string): StructuredToolInterface[] {
  * @param model - The model name
  * @returns Formatted string with all tool descriptions
  */
-export function buildToolDescriptions(model: string): string {
-  return getToolRegistry(model)
+export function buildToolDescriptions(model: string, modelProvider: string = 'openai'): string {
+  return getToolRegistry(model, modelProvider)
     .map((t) => `### ${t.name}\n\n${t.description}`)
     .join('\n\n');
 }


### PR DESCRIPTION
## Summary

- Threads `modelProvider` through the tool creation pipeline (`registry.ts` → `financial-metrics.ts`, `read-filings.ts`) and chat history (`InMemoryChatHistory`) so internal routing/summarization LLM calls use the provider's configured `fastModel` instead of the expensive main model
- Wires `getFastModel()` (which already existed but was never called) into all 5 internal `callLlm` sites: financial metrics routing, read filings planning, read filings item selection, chat history summarization, and chat history message selection
- All functions use `modelProvider: string = 'openai'` defaults so existing callers don't break

## Test plan

- [x] `tsc --noEmit` passes
- [ ] `bun test` passes (tests require `bun` runtime)
- [ ] Manual: verify sub-agent tool calls use the fast model by checking logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)