### PR TITLE
Add Azure AI Foundry Endpoint Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ cp env.example .env
 
 # Edit .env and add your API keys (if using cloud providers)
 # OPENAI_API_KEY=your-openai-api-key
+# AZURE_OPENAI_API_KEY=your-azure-openai-api-key (optional)
+# AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com (optional)
 # ANTHROPIC_API_KEY=your-anthropic-api-key (optional)
 # GOOGLE_API_KEY=your-google-api-key (optional)
 # XAI_API_KEY=your-xai-api-key (optional)

--- a/env.example
+++ b/env.example
@@ -1,5 +1,7 @@
 # LLM API Keys
 OPENAI_API_KEY=your-api-key
+AZURE_OPENAI_API_KEY=your-api-key
+AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
 ANTHROPIC_API_KEY=your-api-key
 GOOGLE_API_KEY=your-api-key
 XAI_API_KEY=your-api-key

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -349,11 +349,16 @@ export async function runCli() {
       const input = new ApiKeyInputComponent();
       input.onSubmit = (value) => modelSelection.handleModelInputSubmit(value);
       input.onCancel = () => modelSelection.handleModelInputSubmit(null);
+      const isAzure = state.pendingProvider === 'azure';
       renderScreenView(
         `Enter model name for ${getProviderDisplayName(state.pendingProvider)}`,
-        'Type or paste the model name from openrouter.ai/models',
+        isAzure
+          ? 'Type your Azure OpenAI deployment name'
+          : 'Type or paste the model name from openrouter.ai/models',
         input,
-        'Examples: anthropic/claude-3.5-sonnet, openai/gpt-4-turbo, meta-llama/llama-3-70b\nEnter to confirm · esc to go back',
+        isAzure
+          ? 'Examples: gpt-5-prod, gpt-4.1-main\nEnter to confirm · esc to go back'
+          : 'Examples: anthropic/claude-3.5-sonnet, openai/gpt-4-turbo, meta-llama/llama-3-70b\nEnter to confirm · esc to go back',
         input,
       );
       return;

--- a/src/controllers/model-selection.ts
+++ b/src/controllers/model-selection.ts
@@ -94,7 +94,7 @@ export class ModelSelectionController {
     }
 
     this.pendingProviderValue = providerId;
-    if (providerId === 'openrouter') {
+    if (providerId === 'openrouter' || providerId === 'azure') {
       this.pendingModelsValue = [];
       this.appStateValue = 'model_input';
       this.emitChange();

--- a/src/model/llm.ts
+++ b/src/model/llm.ts
@@ -1,10 +1,9 @@
-import { AIMessage } from '@langchain/core/messages';
 import { ChatOpenAI } from '@langchain/openai';
 import { ChatAnthropic } from '@langchain/anthropic';
 import { ChatGoogleGenerativeAI } from '@langchain/google-genai';
 import { ChatOllama } from '@langchain/ollama';
 import { ChatPromptTemplate } from '@langchain/core/prompts';
-import { SystemMessage, HumanMessage } from '@langchain/core/messages';
+import { SystemMessage, HumanMessage, AIMessage } from '@langchain/core/messages';
 import { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import { StructuredToolInterface } from '@langchain/core/tools';
 import { Runnable } from '@langchain/core/runnables';
@@ -58,6 +57,14 @@ function getApiKey(envVar: string): string {
   return apiKey;
 }
 
+function getRequiredEnvVar(envVar: string): string {
+  const value = process.env[envVar];
+  if (!value?.trim()) {
+    throw new Error(`[LLM] ${envVar} not found in environment variables`);
+  }
+  return value.trim();
+}
+
 // Factories keyed by provider id — prefix routing is handled by resolveProvider()
 const MODEL_FACTORIES: Record<string, ModelFactory> = {
   anthropic: (name, opts) =>
@@ -90,6 +97,25 @@ const MODEL_FACTORIES: Record<string, ModelFactory> = {
         baseURL: 'https://openrouter.ai/api/v1',
       },
     }),
+  azure: (name, opts) => {
+    const deployment = name.replace(/^azure:/, '').trim();
+
+    if (!deployment) {
+      throw new Error('[Azure OpenAI] Missing deployment name. Use model format azure:<deployment-name>.');
+    }
+
+    const endpoint = getRequiredEnvVar('AZURE_OPENAI_ENDPOINT').replace(/\/+$/, '');
+    const apiKey = getApiKey('AZURE_OPENAI_API_KEY');
+
+    return new ChatOpenAI({
+      model: deployment,
+      ...opts,
+      apiKey,
+      configuration: {
+        baseURL: endpoint
+      },
+    });
+  },
   moonshot: (name, opts) =>
     new ChatOpenAI({
       model: name,

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -67,6 +67,12 @@ export const PROVIDERS: ProviderDef[] = [
     fastModel: 'openrouter:openai/gpt-4o-mini',
   },
   {
+    id: 'azure',
+    displayName: 'Azure OpenAI',
+    modelPrefix: 'azure:',
+    apiKeyEnvVar: 'AZURE_OPENAI_API_KEY',
+  },
+  {
     id: 'ollama',
     displayName: 'Ollama',
     modelPrefix: 'ollama:',

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -56,7 +56,7 @@ export function getDefaultModelForProvider(providerId: string): string | undefin
 }
 
 export function getModelDisplayName(modelId: string): string {
-  const normalizedId = modelId.replace(/^(ollama|openrouter):/, '');
+  const normalizedId = modelId.replace(/^(ollama|openrouter|azure):/, '');
 
   for (const provider of PROVIDERS) {
     const model = provider.models.find((entry) => entry.id === normalizedId || entry.id === modelId);


### PR DESCRIPTION
## Summary
This PR adds support to Azure AI Foundry models which provide access to 11333 models from different vendors (OpenAI, Anthropic, Meta, etc.).

## What changed
- Added `azure` provider registration and routing.
- Wired Azure model creation with deployment-based model IDs (`azure:<deployment-name>`).
- Added Azure env vars:
  - `AZURE_OPENAI_API_KEY`
  - `AZURE_OPENAI_ENDPOINT`
- Updated `/model` flow so Azure uses custom deployment-name input (similar to OpenRouter custom input).
- Updated model display normalization so `azure:` prefixes render cleanly.
- Updated docs (`env.example`, `README.md`) with Azure setup examples.

## Validation
- Verified Azure-related files compile cleanly.
- Note: workspace `bun run typecheck` still reports an unrelated pre-existing error in Exa search typing.

## Why
This enables users running Azure-hosted OpenAI deployments to use Dexter without code changes, while preserving existing provider behavior.