### PR TITLE
feat: add Novita AI as optional LLM provider

### DIFF
--- a/env.example
+++ b/env.example
@@ -6,6 +6,7 @@ XAI_API_KEY=your-api-key
 OPENROUTER_API_KEY=your-api-key
 MOONSHOT_API_KEY=your-api-key
 DEEPSEEK_API_KEY=your-api-key
+NOVITA_API_KEY=your-api-key
 
 # Ollama (Local LLM)
 OLLAMA_BASE_URL=http://127.0.0.1:11434

--- a/src/model/llm.ts
+++ b/src/model/llm.ts
@@ -120,6 +120,15 @@ const MODEL_FACTORIES: Record<string, ModelFactory> = {
       ...opts,
       ...(process.env.OLLAMA_BASE_URL ? { baseUrl: process.env.OLLAMA_BASE_URL } : {}),
     }),
+  novita: (name, opts) =>
+    new ChatOpenAI({
+      model: name.replace(/^novita:/, ''),
+      ...opts,
+      apiKey: getApiKey('NOVITA_API_KEY'),
+      configuration: {
+        baseURL: 'https://api.novita.ai/openai',
+      },
+    }),
 };
 
 const DEFAULT_FACTORY: ModelFactory = (name, opts) =>

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -71,6 +71,13 @@ export const PROVIDERS: ProviderDef[] = [
     displayName: 'Ollama',
     modelPrefix: 'ollama:',
   },
+  {
+    id: 'novita',
+    displayName: 'Novita AI',
+    modelPrefix: 'novita:',
+    apiKeyEnvVar: 'NOVITA_API_KEY',
+    fastModel: 'novita:deepseek-ai/DeepSeek-V3',
+  },
 ];
 
 const defaultProvider = PROVIDERS.find((p) => p.id === 'openai')!;

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -76,7 +76,7 @@ export const PROVIDERS: ProviderDef[] = [
     displayName: 'Novita AI',
     modelPrefix: 'novita:',
     apiKeyEnvVar: 'NOVITA_API_KEY',
-    fastModel: 'novita:deepseek-ai/DeepSeek-V3',
+    fastModel: 'novita:deepseek/deepseek-v3.2',
   },
 ];
 

--- a/src/providers/novita-provider.ts
+++ b/src/providers/novita-provider.ts
@@ -1,0 +1,15 @@
+/**
+ * Novita AI Provider
+ * 
+ * OpenAI-compatible provider for Novita AI (https://novita.ai)
+ * Uses the OpenAI SDK pointed at Novita's endpoint.
+ */
+
+export const NOVITA_CONFIG = {
+  id: 'novita',
+  displayName: 'Novita AI',
+  modelPrefix: 'novita:',
+  apiKeyEnvVar: 'NOVITA_API_KEY',
+  baseURL: 'https://api.novita.ai/openai',
+  fastModel: 'novita:deepseek-ai/DeepSeek-V3',
+};

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -33,6 +33,11 @@ const PROVIDER_MODELS: Record<string, Model[]> = {
     { id: 'deepseek-chat', displayName: 'DeepSeek V3' },
     { id: 'deepseek-reasoner', displayName: 'DeepSeek R1' },
   ],
+  novita: [
+    { id: 'novita:deepseek/deepseek-v3.2', displayName: 'DeepSeek V3.2 (Novita)' },
+    { id: 'novita:minimax/minimax-m2.5', displayName: 'MiniMax M2.5 (Novita)' },
+    { id: 'novita:zai-org/glm-5', displayName: 'GLM-5 (Novita)' },
+  ],
 };
 
 export const PROVIDERS: Provider[] = PROVIDER_DEFS.map((provider) => ({


### PR DESCRIPTION
This PR adds Novita AI as an optional LLM provider.

## Changes
- Added Novita provider to PROVIDERS array in providers.ts
- Added Novita model factory in llm.ts using ChatOpenAI with Novita's OpenAI-compatible endpoint
- Updated env.example with NOVITA_API_KEY
- Created src/providers/novita-provider.ts with configuration constants
- Updated Novita recommended model presets:
  - novita:deepseek/deepseek-v3.2 (fast model)
  - novita:minimax/minimax-m2.5
  - novita:zai-org/glm-5

## Notes
- Endpoint follows Novita OpenAI-compatible base URL: https://api.novita.ai/openai
- Existing provider behavior remains backward compatible