### PR TITLE
Add Gemini 3.1 Pro to Google models

### DIFF
--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -22,7 +22,6 @@ const PROVIDER_MODELS: Record<string, Model[]> = {
   ],
   google: [
     { id: 'gemini-3-flash-preview', displayName: 'Gemini 3 Flash' },
-    { id: 'gemini-3-pro-preview', displayName: 'Gemini 3 Pro' },
     { id: 'gemini-3.1-pro-preview', displayName: 'Gemini 3.1 Pro' },
   ],
   xai: [


### PR DESCRIPTION
Added Google's 3.1 Pro Model to Google Model Options. Ran the sample tests and it 