### PR TITLE
Fix markdown link formatting in WhatsApp README

### DIFF
--- a/src/gateway/channels/whatsapp/README.md
+++ b/src/gateway/channels/whatsapp/README.md
@@ -8,7 +8,7 @@ Chat with Dexter through WhatsApp by linking your phone to the gateway. Messages
 - [🔗 How to Link WhatsApp](#-how-to-link-whatsapp)
 - [🚀 How to Run](#-how-to-run)
 - [💬 How to Chat](#-how-to-chat)
-- [⚙️ Configuration](#️-configuration)
+- [⚙️ Configuration](#⚙️-configuration)
 - [🔄 How to Relink](#-how-to-relink)
 - [🐛 Troubleshooting](#-troubleshooting)
 - [🔧 Full Reset](#-full-reset)


### PR DESCRIPTION
Fixes broken anchor link in Table of Contents. The Configuration section link was missing the emoji character in the anchor reference, causing the link to not properly navigate to the section.