### PR TITLE
Add Docker and Docker Compose support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM oven/bun:1-alpine
+
+WORKDIR /app
+
+COPY package.json bun.lockb* ./
+RUN bun install --frozen-lockfile
+
+COPY . .
+
+ENV NODE_ENV=production
+
+ENTRYPOINT ["bun", "run", "src/index.tsx"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  dexter:
+    build: .
+    image: dexter
+    stdin_open: true
+    tty: true
+    env_file:
+      - .env
+    volumes:
+      - ./.dexter:/app/.dexter


### PR DESCRIPTION
Adds a minimal `Dockerfile` using the official Bun Alpine image and a `docker-compose.yml` that mounts the `.dexter` data directory and passes API keys via `.env`. Contributors can now run `docker compose up` to get started without installing Bun or any dependencies locally.

Addresses #36.