### PR TITLE
Allow models to be switched without restarting the cli

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -171,13 +171,16 @@ export async function runCli() {
     tui.requestRender();
   };
 
+  let agentRunner: AgentRunnerController; 
+
   const modelSelection = new ModelSelectionController(onError, () => {
     intro.setModel(modelSelection.model);
+    agentRunner.updateAgentConfig({ model: modelSelection.model, modelProvider: modelSelection.provider });
     renderSelectionOverlay();
     tui.requestRender();
   });
 
-  const agentRunner = new AgentRunnerController(
+  agentRunner = new AgentRunnerController(
     { model: modelSelection.model, modelProvider: modelSelection.provider, maxIterations: 10 },
     modelSelection.inMemoryChatHistory,
     () => {

--- a/src/controllers/agent-runner.ts
+++ b/src/controllers/agent-runner.ts
@@ -20,7 +20,7 @@ export class AgentRunnerController {
   private workingStateValue: WorkingState = { status: 'idle' };
   private errorValue: string | null = null;
   private pendingApprovalValue: { tool: string; args: Record<string, unknown> } | null = null;
-  private readonly agentConfig: AgentConfig;
+  private agentConfig: AgentConfig;
   private readonly inMemoryChatHistory: InMemoryChatHistory;
   private readonly onChange?: ChangeListener;
   private abortController: AbortController | null = null;
@@ -274,5 +274,9 @@ export class AgentRunnerController {
 
   private emitChange() {
     this.onChange?.();
+  }
+
+  public updateAgentConfig(config: Partial<AgentConfig>) {
+    this.agentConfig = { ...this.agentConfig, ...config };
   }
 }


### PR DESCRIPTION
When using the `/model` command the model is not changed until the cli is reset.  This PR updates the agentConfig so that the new model selection is used.