### PR TITLE
fix(cron): escape JSON curly braces in tool description to prevent Langchain parsing error

### DIFF
--- a/src/tools/cron/cron-tool.ts
+++ b/src/tools/cron/cron-tool.ts
@@ -27,9 +27,9 @@ Jobs run as isolated agent turns with full tool access, delivering results via W
 
 ## Schedule Types
 
-- **at**: One-shot at a specific time. \`{ "kind": "at", "at": "2026-04-01T14:00:00Z" }\`
-- **every**: Recurring interval in milliseconds. \`{ "kind": "every", "everyMs": 3600000 }\` (1 hour)
-- **cron**: Cron expression with optional timezone. \`{ "kind": "cron", "expr": "0 9 * * 1-5", "tz": "America/New_York" }\`
+- **at**: One-shot at a specific time. \`{{ "kind": "at", "at": "2026-04-01T14:00:00Z" }}\`
+- **every**: Recurring interval in milliseconds. \`{{ "kind": "every", "everyMs": 3600000 }}\` (1 hour)
+- **cron**: Cron expression with optional timezone. \`{{ "kind": "cron", "expr": "0 9 * * 1-5", "tz": "America/New_York" }}\`
 
 ## Fulfillment Modes
 


### PR DESCRIPTION
The newly added Cron tool included literal JSON schedules like { "kind": "at" }. When injected into the system prompt, LangChain's PromptTemplate interpreted the single curly braces as input variables, crashing the agent with an INVALID_PROMPT_INPUT (Missing value for input variable) error. This PR double-escapes them to {{...}} to fix the interpolation.

Error on Windows 11:

⏺ Error: [OpenRouter API] Missing value for input variable "kind": "at", "at": "2026-04-01T14:00:00Z"

Troubleshooting URL: https://docs.langchain.com/oss/javascript/langchain/errors/INVALID_PROMPT_INPUT/

✻ 2s