### PR TITLE
feat: support OPENAI_BASE_URL environment variable

### DIFF
--- a/src/model/llm.ts
+++ b/src/model/llm.ts
@@ -127,6 +127,7 @@ const DEFAULT_FACTORY: ModelFactory = (name, opts) =>
     model: name,
     ...opts,
     apiKey: getApiKey('OPENAI_API_KEY'),
+    ...(process.env.OPENAI_BASE_URL ? { configuration: { baseURL: process.env.OPENAI_BASE_URL } } : {}),
   });
 
 export function getChatModel(


### PR DESCRIPTION
## Summary

Adds support for `OPENAI_BASE_URL` environment variable to enable custom OpenAI-compatible API endpoints.

## Motivation

Many providers offer OpenAI-compatible APIs (Aliyun DashScope, local LLM proxies, etc.), but Dexter's default OpenAI factory doesn't support custom base URLs. This PR follows the same pattern as `OLLAMA_BASE_URL` to enable these use cases.

## Changes

- Modified `DEFAULT_FACTORY` in `src/model/llm.ts` to check for `OPENAI_BASE_URL` env var
- When set, passes it to ChatOpenAI's `configuration.baseURL`

## Usage Example

```env
OPENAI_API_KEY=sk-xxx
OPENAI_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
MODEL=qwen-plus
```

## Testing

Tested with Aliyun DashScope (qwen-plus model) successfully.