### PR TITLE
feat: add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.env
+.dexter/
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM oven/bun:1
+
+WORKDIR /app
+
+# Copy package files for layer caching
+COPY package.json bun.lock ./
+
+# Install dependencies (postinstall runs: playwright install chromium)
+RUN bun install
+
+# Install Chromium system-level dependencies for Playwright
+RUN ./node_modules/.bin/playwright install-deps chromium
+
+# Copy the rest of the source
+COPY . .
+
+CMD ["bun", "run", "src/index.tsx"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Dexter is an autonomous financial research agent that thinks, plans, and learns 
 - [✅ Prerequisites](#-prerequisites)
 - [💻 How to Install](#-how-to-install)
 - [🚀 How to Run](#-how-to-run)
+- [🐳 How to Run with Docker](#-how-to-run-with-docker)
 - [📊 How to Evaluate](#-how-to-evaluate)
 - [🐛 How to Debug](#-how-to-debug)
 - [📱 How to Use with WhatsApp](#-how-to-use-with-whatsapp)
@@ -106,6 +107,28 @@ Or with watch mode for development:
 ```bash
 bun dev
 ```
+
+## 🐳 How to Run with Docker
+
+Run Dexter in a container without installing Bun or Playwright locally.
+
+1. Copy the environment file and add your API keys:
+```bash
+cp env.example .env
+```
+
+2. Build and run:
+```bash
+docker compose run --rm dexter
+```
+
+Or build and run manually:
+```bash
+docker build -t dexter .
+docker run -it --env-file .env -v $(pwd)/.dexter:/app/.dexter dexter
+```
+
+> **Note:** The first build downloads Chromium for Playwright web scraping and may take a few minutes.
 
 ## 📊 How to Evaluate
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  dexter:
+    build: .
+    stdin_open: true
+    tty: true
+    env_file:
+      - .env
+    volumes:
+      - ./.dexter:/app/.dexter


### PR DESCRIPTION
## Summary

- Add `Dockerfile` using `oven/bun:1` as base image
- Add `docker-compose.yml` for easy one-command startup
- Add `.dockerignore` to exclude `.env` and build artifacts
- Add **🐳 How to Run with Docker** section to README

## Motivation

Closes #152 — users can now run Dexter without installing Bun or Playwright locally.

## How it works

The `Dockerfile`:
1. Installs all Node/Bun dependencies (the `postinstall` hook automatically runs `playwright install chromium`)
2. Runs `playwright install-deps chromium` to install the required OS-level libraries for Chromium
3. Exposes the interactive CLI via `stdin_open`/`tty`

## Usage

```bash
cp env.example .env
# add your API keys to .env
docker compose run --rm dexter
```

## Test plan

- [ ] `docker build -t dexter .` completes without errors
- [ ] `docker run -it --env-file .env dexter` launches the Dexter CLI
- [ ] `docker compose run --rm dexter` works end-to-end
- [ ] Playwright browser tool works inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)