### PR TITLE
fix cli scroll flicker

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,10 +1,12 @@
 import { Container, ProcessTerminal, Spacer, Text, TUI } from '@mariozechner/pi-tui';
 import type {
+  AgentEvent,
   ApprovalDecision,
   ToolEndEvent,
   ToolErrorEvent,
   ToolStartEvent,
 } from './agent/index.js';
+import type { DisplayEvent } from './agent/types.js';
 import { getApiKeyNameForProvider, getProviderDisplayName } from './utils/env.js';
 import { defaultQueue } from './utils/message-queue.js';
 import { logger } from './utils/logger.js';
@@ -28,6 +30,7 @@ import {
 } from './components/index.js';
 import { editorTheme, theme } from './theme.js';
 import { matchCommands, type SlashCommand } from './commands/index.js';
+import type { HistoryItem } from './types.js';
 
 function truncateAtWord(str: string, maxLength: number): string {
   if (str.length <= maxLength) {
@@ -103,12 +106,7 @@ function renderHistory(chatLog: ChatLogComponent, history: AgentRunnerController
     for (const display of item.events) {
       const event = display.event;
       if (event.type === 'thinking') {
-        const message = event.message.trim();
-        if (message) {
-          chatLog.addChild(
-            new Text(message.length > 200 ? `${message.slice(0, 200)}...` : message, 0, 0),
-          );
-        }
+        chatLog.addThinking(event.message);
         continue;
       }
 
@@ -175,12 +173,179 @@ function renderHistory(chatLog: ChatLogComponent, history: AgentRunnerController
   }
 }
 
+interface RenderedDisplayState {
+  completed: boolean;
+  progressMessage?: string;
+  endEventType?: AgentEvent['type'];
+}
+
+interface RenderedHistoryItemState {
+  queryRendered: boolean;
+  interruptedRendered: boolean;
+  answerRendered: boolean;
+  statsRendered: boolean;
+  events: Map<string, RenderedDisplayState>;
+}
+
+function createRenderedHistoryItemState(): RenderedHistoryItemState {
+  return {
+    queryRendered: false,
+    interruptedRendered: false,
+    answerRendered: false,
+    statsRendered: false,
+    events: new Map(),
+  };
+}
+
+function syncDisplayEvent(
+  chatLog: ChatLogComponent,
+  item: HistoryItem,
+  display: DisplayEvent,
+  previous: RenderedDisplayState | undefined,
+) {
+  const event = display.event;
+
+  if (event.type === 'thinking') {
+    if (!previous) {
+      chatLog.addThinking(event.message);
+    }
+    return;
+  }
+
+  if (event.type === 'tool_start') {
+    const toolStart = event as ToolStartEvent;
+    if (!previous) {
+      chatLog.startTool(display.id, toolStart.tool, toolStart.args);
+    }
+
+    if (display.progressMessage && display.progressMessage !== previous?.progressMessage) {
+      chatLog.updateToolProgress(display.id, display.progressMessage);
+    }
+
+    if (!display.completed) {
+      return;
+    }
+
+    if (previous?.completed && previous.endEventType === display.endEvent?.type) {
+      return;
+    }
+
+    if (display.endEvent?.type === 'tool_end') {
+      const done = display.endEvent as ToolEndEvent;
+      chatLog.completeTool(
+        display.id,
+        summarizeToolResult(done.tool, toolStart.args, done.result),
+        done.duration,
+      );
+      return;
+    }
+
+    if (display.endEvent?.type === 'tool_error') {
+      const toolError = display.endEvent as ToolErrorEvent;
+      chatLog.errorTool(display.id, toolError.error);
+      return;
+    }
+
+    if (item.status === 'interrupted' && !previous?.completed) {
+      chatLog.interruptActiveTools();
+    }
+    return;
+  }
+
+  if (previous) {
+    return;
+  }
+
+  if (event.type === 'tool_approval') {
+    const approval = chatLog.startTool(display.id, event.tool, event.args);
+    approval.setApproval(event.approved);
+    return;
+  }
+
+  if (event.type === 'tool_denied') {
+    const denied = chatLog.startTool(display.id, event.tool, event.args);
+    const path = (event.args.path as string) ?? '';
+    denied.setDenied(path, event.tool);
+    return;
+  }
+
+  if (event.type === 'tool_limit') {
+    return;
+  }
+
+  if (event.type === 'context_cleared') {
+    chatLog.addContextCleared(event.clearedCount, event.keptCount);
+    return;
+  }
+
+  if (event.type === 'microcompact') {
+    chatLog.addMicrocompact(event.cleared, event.tokensSaved);
+    return;
+  }
+
+  if (event.type === 'queue_drain') {
+    chatLog.addQueueDrain(event.messageCount);
+    return;
+  }
+
+  if (event.type === 'compaction' && event.phase === 'end') {
+    chatLog.addCompaction(event.success ?? false, event.preCompactTokens, event.postCompactTokens);
+  }
+}
+
+function syncHistory(
+  chatLog: ChatLogComponent,
+  history: AgentRunnerController['history'],
+  renderedState: Map<string, RenderedHistoryItemState>,
+) {
+  for (const item of history) {
+    let state = renderedState.get(item.id);
+    if (!state) {
+      state = createRenderedHistoryItemState();
+      renderedState.set(item.id, state);
+    }
+
+    if (!state.queryRendered) {
+      chatLog.addQuery(item.query);
+      chatLog.resetToolGrouping();
+      state.queryRendered = true;
+    }
+
+    if (item.status === 'interrupted' && !state.interruptedRendered) {
+      chatLog.interruptActiveTools();
+      chatLog.addInterrupted();
+      state.interruptedRendered = true;
+    }
+
+    for (const display of item.events) {
+      syncDisplayEvent(chatLog, item, display, state.events.get(display.id));
+      state.events.set(display.id, {
+        completed: !!display.completed,
+        progressMessage: display.progressMessage,
+        endEventType: display.endEvent?.type,
+      });
+    }
+
+    if (item.answer && !state.answerRendered) {
+      chatLog.finalizeAnswer(item.answer);
+      state.answerRendered = true;
+    }
+
+    if (item.status === 'complete' && !state.statsRendered) {
+      chatLog.addPerformanceStats(item.duration ?? 0, item.tokenUsage, item.tokensPerSecond);
+      state.statsRendered = true;
+    }
+  }
+}
+
 export async function runCli() {
   const tui = new TUI(new ProcessTerminal());
   const root = new Container();
   const chatLog = new ChatLogComponent(tui);
+  const renderedHistoryState = new Map<string, RenderedHistoryItemState>();
   const inputHistory = new InputHistoryController(() => tui.requestRender());
   let lastError: string | null = null;
+  let showingOverlay = false;
 
   const onError = (message: string) => {
     lastError = message;
@@ -203,9 +368,15 @@ export async function runCli() {
     { model: modelSelection.model, modelProvider: modelSelection.provider, maxIterations: 10 },
     modelSelection.inMemoryChatHistory,
     () => {
-      renderHistory(chatLog, agentRunner.history);
+      syncHistory(chatLog, agentRunner.history, renderedHistoryState);
+      refreshError();
       workingIndicator.setState(agentRunner.workingState);
-      renderSelectionOverlay();
+
+      const shouldShowOverlay = modelSelection.isInSelectionFlow() || !!agentRunner.pendingApproval;
+      if (shouldShowOverlay || showingOverlay) {
+        renderSelectionOverlay();
+      }
+
       tui.requestRender();
     },
   );
@@ -353,6 +524,7 @@ export async function runCli() {
   };
 
   const renderMainView = () => {
+    showingOverlay = false;
     root.clear();
     root.addChild(intro);
     root.addChild(chatLog);
@@ -389,6 +561,7 @@ export async function runCli() {
     footer?: string,
     focusTarget?: any,
   ) => {
+    showingOverlay = true;
     root.clear();
     root.addChild(createScreen(title, description, body, footer));
     if (focusTarget) {
@@ -580,6 +753,7 @@ export async function runCli() {
   for (const msg of inputHistory.getMessages().reverse()) {
     editor.addToHistory(msg);
   }
+  syncHistory(chatLog, agentRunner.history, renderedHistoryState);
   renderSelectionOverlay();
   refreshError();
 

--- a/src/components/chat-log.ts
+++ b/src/components/chat-log.ts
@@ -171,6 +171,14 @@ export class ChatLogComponent extends Container {
     this.addChild(new Text(`${theme.muted('⎿  Interrupted · What should Dexter do instead?')}`, 0, 0));
   }
 
+  addThinking(message: string) {
+    const trimmed = message.trim();
+    if (!trimmed) {
+      return;
+    }
+    this.addChild(new Text(trimmed.length > 200 ? `${trimmed.slice(0, 200)}...` : trimmed, 0, 0));
+  }
+
   startTool(toolCallId: string, toolName: string, args: Record<string, unknown>) {
     if (toolName !== 'browser') {
       this.currentBrowserSession = null;
@@ -256,6 +264,14 @@ export class ChatLogComponent extends Container {
       return;
     }
     existing.setDenied(path, tool);
+  }
+
+  interruptActiveTools() {
+    const uniqueComponents = new Set(this.toolById.values());
+    for (const component of uniqueComponents) {
+      component.dispose?.();
+    }
+    this.resetToolGrouping();
   }
 
   finalizeAnswer(text: string) {

--- a/src/components/tool-event.ts
+++ b/src/components/tool-event.ts
@@ -56,19 +56,13 @@ function approvalLabel(decision: ApprovalDecision): string {
   }
 }
 
-const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
-
 export class ToolEventComponent extends Container {
-  private readonly tui: TUI;
   private readonly header: Text;
   private completedDetails: Text[] = [];
   private activeDetail: Text | null = null;
-  private spinnerInterval: ReturnType<typeof setInterval> | null = null;
-  private spinnerFrame: number = 0;
 
-  constructor(tui: TUI, tool: string, args: Record<string, unknown>) {
+  constructor(_tui: TUI, tool: string, args: Record<string, unknown>) {
     super();
-    this.tui = tui;
     this.addChild(new Spacer(1));
     const title = `${formatToolName(tool)}${args ? `${theme.muted('(')}${formatArgs(tool, args)}${theme.muted(')')}` : ''}`;
     this.header = new Text(`⏺ ${title}`, 0, 0);
@@ -78,14 +72,8 @@ export class ToolEventComponent extends Container {
   setActive(progressMessage?: string) {
     this.clearDetail();
     const message = progressMessage || 'Searching...';
-    this.activeDetail = new Text(`${theme.muted(`⎿  ${SPINNER_FRAMES[0]}`)} ${message}`, 0, 0);
+    this.activeDetail = new Text(`${theme.muted('⎿  …')} ${message}`, 0, 0);
     this.addChild(this.activeDetail);
-    this.spinnerFrame = 0;
-    this.spinnerInterval = setInterval(() => {
-      this.spinnerFrame = (this.spinnerFrame + 1) % SPINNER_FRAMES.length;
-      this.activeDetail?.setText(`${theme.muted(`⎿  ${SPINNER_FRAMES[this.spinnerFrame]}`)} ${message}`);
-      this.tui.requestRender();
-    }, 80);
   }
 
   setComplete(summary: string, duration: number) {
@@ -137,10 +125,6 @@ export class ToolEventComponent extends Container {
   }
 
   private clearDetail() {
-    if (this.spinnerInterval) {
-      clearInterval(this.spinnerInterval);
-      this.spinnerInterval = null;
-    }
     if (this.activeDetail) {
       this.removeChild(this.activeDetail);
       this.activeDetail = null;

--- a/src/components/working-indicator.ts
+++ b/src/components/working-indicator.ts
@@ -1,18 +1,18 @@
-import { Container, Loader, type TUI } from '@mariozechner/pi-tui';
+import { Container, Text, type TUI } from '@mariozechner/pi-tui';
 import type { WorkingState } from '../types.js';
 import { getRandomThinkingVerb } from '../utils/thinking-verbs.js';
 import { theme } from '../theme.js';
 
 export class WorkingIndicatorComponent extends Container {
-  private readonly tui: TUI;
-  private loader: Loader | null = null;
+  private readonly body: Text;
   private state: WorkingState = { status: 'idle' };
   private thinkingVerb = getRandomThinkingVerb();
   private prevStatus: WorkingState['status'] = 'idle';
 
-  constructor(tui: TUI) {
+  constructor(_tui: TUI) {
     super();
-    this.tui = tui;
+    this.body = new Text('', 0, 0);
+    this.addChild(this.body);
     this.renderIdle();
   }
 
@@ -29,57 +29,27 @@ export class WorkingIndicatorComponent extends Container {
     this.prevStatus = state.status;
     this.state = state;
     if (state.status === 'idle') {
-      this.stopLoader();
       this.renderIdle();
       return;
     }
     this.renderBusy();
   }
 
-  dispose() {
-    this.stopLoader();
-  }
+  dispose() {}
 
   private renderIdle() {
-    this.clear();
+    this.body.setText('');
   }
 
   private renderBusy() {
-    this.clear();
-    this.ensureLoader();
-    this.updateMessage();
-  }
-
-  private ensureLoader() {
-    if (this.loader) {
-      this.addChild(this.loader);
-      return;
-    }
-    this.loader = new Loader(
-      this.tui,
-      (spinner) => theme.primary(spinner),
-      (text) => theme.primary(text),
-      '',
-    );
-    this.addChild(this.loader);
-  }
-
-  private stopLoader() {
-    if (!this.loader) {
-      return;
-    }
-    this.loader.stop();
-    this.loader = null;
-  }
-
-  private updateMessage() {
-    if (!this.loader || this.state.status === 'idle') {
+    if (this.state.status === 'idle') {
+      this.body.setText('');
       return;
     }
     if (this.state.status === 'approval') {
-      this.loader.setMessage('Waiting for approval... (esc to interrupt)');
+      this.body.setText(theme.primary('… Waiting for approval... (esc to interrupt)'));
       return;
     }
-    this.loader.setMessage(`${this.thinkingVerb}... (esc to interrupt)`);
+    this.body.setText(theme.primary(`… ${this.thinkingVerb}... (esc to interrupt)`));
   }
 }


### PR DESCRIPTION
## Summary
- stop rebuilding the full CLI transcript on every agent state change by syncing chat history incrementally
- keep the main view mounted during normal operation and only re-render the overlay layer when selection or approval UI is active
- remove the timer-driven tool and working-indicator spinners so scrolling is not fighting 80ms redraws

## Root cause
The CLI was clearing and rebuilding large parts of the `pi-tui` tree during live updates, and two animated indicators were still forcing continuous renders. That combination caused severe flicker while scrolling because the terminal kept repainting active lines instead of only reacting to real state changes.

## Validation
- `bun run typecheck`
- `bun test`


✅ tested on macos