### PR TITLE
fix(cron): flatten schedule schema for Gemini tool compatibility

### DIFF
--- a/src/tools/cron/cron-tool.ts
+++ b/src/tools/cron/cron-tool.ts
@@ -51,22 +51,14 @@ Write it as a clear instruction, e.g.: "Check the current price of AAPL. If it h
 - Minimum interval for "every" schedules is 60 seconds
 `.trim();
 
-const scheduleSchema = z.discriminatedUnion('kind', [
-  z.object({
-    kind: z.literal('at'),
-    at: z.string().describe('ISO-8601 timestamp for one-shot execution'),
-  }),
-  z.object({
-    kind: z.literal('every'),
-    everyMs: z.number().min(60000).describe('Interval in milliseconds (minimum 60000 = 1 minute)'),
-    anchorMs: z.number().optional().describe('Optional anchor timestamp in ms'),
-  }),
-  z.object({
-    kind: z.literal('cron'),
-    expr: z.string().describe('Cron expression (5 or 6 fields)'),
-    tz: z.string().optional().describe('IANA timezone (default: system timezone)'),
-  }),
-]);
+const scheduleSchema = z.object({
+  kind: z.enum(['at', 'every', 'cron']).describe('Type of schedule'),
+  at: z.string().optional().describe('ISO-8601 timestamp for one-shot execution (required for kind="at")'),
+  everyMs: z.number().min(60000).optional().describe('Interval in milliseconds (minimum 60000 = 1 minute; required for kind="every")'),
+  anchorMs: z.number().optional().describe('Optional anchor timestamp in ms (for kind="every")'),
+  expr: z.string().optional().describe('Cron expression (5 or 6 fields; required for kind="cron")'),
+  tz: z.string().optional().describe('IANA timezone (default: system timezone; for kind="cron")'),
+});
 
 const cronToolSchema = z.object({
   action: z.enum(['list', 'add', 'update', 'remove', 'run']),


### PR DESCRIPTION
### Summary

Gemini API (v1beta) currently does not support `oneOf` or `const` keywords in tool function declarations. Using `z.discriminatedUnion` in the `cron` tool's schema generates a JSON schema with these keywords, causing a `400 Bad Request` (Invalid JSON payload) during initialization when using Gemini models.

### Changes

- Refactored `scheduleSchema` in `src/tools/cron/cron-tool.ts` from a discriminated union to a flat object with optional fields.
- Updated descriptions for the now-optional fields (`at`, `everyMs`, `expr`) to indicate their requirement based on the selected `kind`.

### Impact

- Fixes launch-blocking 400 errors for users with Gemini models.
- Maintains full functionality for existing scheduling logic (the cast to `CronSchedule` remains safe as the flat object is a superset of the possible union members).

### Error Reference

```
⏺ Error: [Google API] [GoogleGenerativeAI Error]: Error fetching from https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-latest:generateContent: [400 Bad Request] Invalid JSON payload received. Unknown name "const" at 'tools[0].function_declarations[10].parameters.properties[3].value.one_of...'
```