### PR TITLE
Fix model selector not responding to arrow keys

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -451,7 +451,9 @@ export async function runCli() {
         queueLength: defaultQueue.length(),
       });
     }
-    tui.setFocus(editor);
+    if (!modelSelection.isInSelectionFlow() && !agentRunner.pendingApproval) {
+      tui.setFocus(editor);
+    }
   };
 
   /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When the user types `/model` to open the model selection menu, the arrow keys (and `j`/`k` vim bindings) do not move the selection cursor. The overlay appears correctly but keyboard navigation is broken. (Fixes #225)

## Root Cause

The `updateView()` function in `src/cli.ts` unconditionally calls `tui.setFocus(editor)` on every invocation. This steals focus from the `VimSelectList` overlay in two scenarios:

1. **Slash autocomplete selection path**: When the user selects `/model` from the slash suggestions, `editor.onSlashSelect` calls `handleSlashCommand('model')` which opens the overlay and focuses the selector — but then immediately calls `updateView()`, which moves focus back to the editor.

2. **Agent runner updates**: The agent runner's `onChange` callback calls `updateView()` on every event while processing, which would steal focus from any open overlay mid-query.

Since pi-tui's `SelectList` only receives key events when it has focus, arrow keys are routed to the `CustomEditor` instead and never reach the model/provider selector.

## Fix

Guard the `tui.setFocus(editor)` call in `updateView()` so it only fires when no overlay flow is active:

```typescript
if (!modelSelection.isInSelectionFlow() && !agentRunner.pendingApproval) {
  tui.setFocus(editor);
}
```

This ensures focus remains on the overlay's selector component (for model selection, provider selection, and approval prompts) and is only returned to the editor when the overlay is dismissed.

## Testing

- `bun run typecheck` passes
- `bun test` passes (37/37 tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5a623be-5640-425e-9d80-8f09db59d373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5a623be-5640-425e-9d80-8f09db59d373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

