### PR TITLE
feat(search): add Seltz as a web search provider

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "linkedom": "^0.18.12",
         "playwright": "^1.58.2",
         "qrcode-terminal": "^0.12.0",
+        "seltz": "^1.0.0",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -261,6 +262,8 @@
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
 
+    "@bufbuild/protobuf": ["@bufbuild/protobuf@2.12.0", "", {}, "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA=="],
+
     "@cacheable/memory": ["@cacheable/memory@2.0.7", "", { "dependencies": { "@cacheable/utils": "^2.3.3", "@keyv/bigmap": "^1.3.0", "hookified": "^1.14.0", "keyv": "^5.5.5" } }, "sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A=="],
 
     "@cacheable/node-cache": ["@cacheable/node-cache@1.7.6", "", { "dependencies": { "cacheable": "^2.3.1", "hookified": "^1.14.0", "keyv": "^5.5.5" } }, "sha512-6Omk2SgNnjtxB5f/E6bTIWIt5xhdpx39fGNRQgU9lojvRxU68v+qY+SXXLsp3ZGukqoPjsK21wZ6XABFr/Ge3A=="],
@@ -324,6 +327,10 @@
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
     "@google/generative-ai": ["@google/generative-ai@0.24.1", "", {}, "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q=="],
+
+    "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
+
+    "@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
 
     "@hapi/boom": ["@hapi/boom@9.1.4", "", { "dependencies": { "@hapi/hoek": "9.x.x" } }, "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw=="],
 
@@ -422,6 +429,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
     "@keyv/bigmap": ["@keyv/bigmap@1.3.1", "", { "dependencies": { "hashery": "^1.4.0", "hookified": "^1.15.0" }, "peerDependencies": { "keyv": "^5.6.0" } }, "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ=="],
 
@@ -871,13 +880,15 @@
 
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
 
-    "libsignal": ["@whiskeysockets/libsignal-node@github:whiskeysockets/libsignal-node#1c30d7d", { "dependencies": { "curve25519-js": "^0.0.4", "protobufjs": "6.8.8" } }, "WhiskeySockets-libsignal-node-1c30d7d"],
+    "libsignal": ["@whiskeysockets/libsignal-node@github:whiskeysockets/libsignal-node#1c30d7d", { "dependencies": { "curve25519-js": "^0.0.4", "protobufjs": "6.8.8" } }, "WhiskeySockets-libsignal-node-1c30d7d", "sha512-5q4/OuDQaMYx3RpDqMqS3WYyqjrsSMpU8ipQZtpYnm5l6DwNoLV9oIYMDK0NILKW+tyk3tVCIA11BMYQ+A1+GA=="],
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
     "linkedom": ["linkedom@0.18.12", "", { "dependencies": { "css-select": "^5.1.0", "cssom": "^0.5.0", "html-escaper": "^3.0.3", "htmlparser2": "^10.0.0", "uhyphen": "^0.2.0" }, "peerDependencies": { "canvas": ">= 2" }, "optionalPeers": ["canvas"] }, "sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q=="],
 
     "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
+    "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
 
     "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
 
@@ -1046,6 +1057,8 @@
     "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
+
+    "seltz": ["seltz@1.0.0", "", { "dependencies": { "@bufbuild/protobuf": "^2.0.0", "@grpc/grpc-js": "^1.12.0" } }, "sha512-ahE/2wWHIwK26Aixwqbl1SFhyBIqAQ0n9veRzFqAo4X/+ebMggn7som1HIlin0qk9yYfLDyzzhYVs69qWSWrew=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 

--- a/env.example
+++ b/env.example
@@ -17,9 +17,10 @@ OLLAMA_BASE_URL=http://127.0.0.1:11434
 # Stock Market API Key
 FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
 
-# Web Search API Keys (Exa → Perplexity → Tavily)
+# Web Search API Keys (Exa → Perplexity → Seltz → Tavily)
 EXASEARCH_API_KEY=your-exa-api-key
 PERPLEXITY_API_KEY=your-perplexity-api-key
+SELTZ_API_KEY=your-seltz-api-key
 TAVILY_API_KEY=your-tavily-api-key
 
 # X/Twitter API (enables x_search tool for public sentiment research)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dexter-ts",
-  "version": "2026.3.25",
+  "version": "2026.4.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dexter-ts",
-      "version": "2026.3.25",
+      "version": "2026.4.25",
       "hasInstallScript": true,
       "dependencies": {
         "@langchain/anthropic": "^1.3.25",
@@ -29,6 +29,7 @@
         "linkedom": "^0.18.12",
         "playwright": "^1.58.2",
         "qrcode-terminal": "^0.12.0",
+        "seltz": "^1.0.0",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -91,7 +92,6 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3027,6 +3027,12 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
+      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
     "node_modules/@cacheable/memory": {
       "version": "2.0.7",
       "license": "MIT",
@@ -3067,6 +3073,7 @@
       "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3511,16 +3518,42 @@
         "node": ">=18"
       }
     },
-    "node_modules/@eshaz/web-worker": {
-      "version": "1.2.2",
-      "license": "Apache-2.0",
-      "optional": true
-    },
     "node_modules/@google/generative-ai": {
       "version": "0.24.1",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@hapi/boom": {
@@ -3537,6 +3570,7 @@
     "node_modules/@img/colour": {
       "version": "1.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3551,6 +3585,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3573,6 +3608,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3593,6 +3629,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3609,6 +3646,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3625,6 +3663,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3641,6 +3680,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3657,6 +3697,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3673,6 +3714,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3689,6 +3731,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3705,6 +3748,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3721,6 +3765,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3737,6 +3782,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -3753,6 +3799,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3775,6 +3822,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3797,6 +3845,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3819,6 +3868,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3841,6 +3891,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3863,6 +3914,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3885,6 +3937,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3907,6 +3960,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3926,6 +3980,7 @@
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
       },
@@ -3948,6 +4003,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3967,6 +4023,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -3986,6 +4043,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -5254,6 +5312,16 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/@keyv/bigmap": {
       "version": "1.3.1",
       "license": "MIT",
@@ -5289,7 +5357,6 @@
     "node_modules/@langchain/core": {
       "version": "1.1.36",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "@standard-schema/spec": "^1.1.0",
@@ -5430,7 +5497,6 @@
     "node_modules/@langchain/exa/node_modules/exa-js/node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -5605,53 +5671,6 @@
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "license": "MIT"
-    },
-    "node_modules/@thi.ng/bitstream": {
-      "version": "2.4.40",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/postspectacular"
-        },
-        {
-          "type": "patreon",
-          "url": "https://patreon.com/thing_umbrella"
-        },
-        {
-          "type": "liberapay",
-          "url": "https://liberapay.com/thi.ng"
-        }
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@thi.ng/errors": "^2.6.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@thi.ng/errors": {
-      "version": "2.6.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/postspectacular"
-        },
-        {
-          "type": "patreon",
-          "url": "https://patreon.com/thing_umbrella"
-        },
-        {
-          "type": "liberapay",
-          "url": "https://liberapay.com/thi.ng"
-        }
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
@@ -5888,53 +5907,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@wasm-audio-decoders/common": {
-      "version": "9.0.7",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@eshaz/web-worker": "1.2.2",
-        "simple-yenc": "^1.0.4"
-      }
-    },
-    "node_modules/@wasm-audio-decoders/flac": {
-      "version": "0.2.10",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@wasm-audio-decoders/common": "9.0.7",
-        "codec-parser": "2.5.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/eshaz"
-      }
-    },
-    "node_modules/@wasm-audio-decoders/ogg-vorbis": {
-      "version": "0.1.20",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@wasm-audio-decoders/common": "9.0.7",
-        "codec-parser": "2.5.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/eshaz"
-      }
-    },
-    "node_modules/@wasm-audio-decoders/opus-ml": {
-      "version": "0.0.2",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@wasm-audio-decoders/common": "9.0.7"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/eshaz"
-      }
-    },
     "node_modules/@whiskeysockets/baileys": {
       "version": "7.0.0-rc.9",
       "hasInstallScript": true,
@@ -6002,7 +5974,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6051,24 +6022,10 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/audio-buffer": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/audio-type": {
-      "version": "2.2.1",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "30.3.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/transform": "30.3.0",
         "@types/babel__core": "^7.20.5",
@@ -6321,7 +6278,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -6498,7 +6454,6 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -6511,7 +6466,6 @@
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -6524,12 +6478,10 @@
     },
     "node_modules/cliui/node_modules/string-width/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6537,7 +6489,6 @@
     },
     "node_modules/cliui/node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -6553,7 +6504,6 @@
     },
     "node_modules/cliui/node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -6573,11 +6523,6 @@
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
       }
-    },
-    "node_modules/codec-parser": {
-      "version": "2.5.0",
-      "license": "LGPL-3.0-or-later",
-      "optional": true
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.3",
@@ -6884,7 +6829,6 @@
       "version": "4.3.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6979,7 +6923,6 @@
     "node_modules/dotenv": {
       "version": "17.3.1",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7070,7 +7013,6 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7150,7 +7092,6 @@
     "node_modules/exa-js/node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -7316,7 +7257,6 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -7883,7 +7823,6 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -10312,7 +10251,6 @@
     "node_modules/keyv": {
       "version": "5.6.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -10473,6 +10411,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "dev": true,
@@ -10627,18 +10571,6 @@
       "version": "0.5.3",
       "license": "MIT"
     },
-    "node_modules/mpg123-decoder": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@wasm-audio-decoders/common": "9.0.7"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/eshaz"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "license": "MIT"
@@ -10741,14 +10673,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-wav": {
-      "version": "0.0.2",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=4.4.0"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "dev": true,
@@ -10776,21 +10700,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
-    "node_modules/ogg-opus-decoder": {
-      "version": "1.7.3",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@wasm-audio-decoders/common": "9.0.7",
-        "@wasm-audio-decoders/opus-ml": "0.0.2",
-        "codec-parser": "2.5.0",
-        "opus-decoder": "0.7.11"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/eshaz"
       }
     },
     "node_modules/ollama": {
@@ -10831,7 +10740,6 @@
     "node_modules/openai": {
       "version": "6.32.0",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -10846,18 +10754,6 @@
         "zod": {
           "optional": true
         }
-      }
-    },
-    "node_modules/opus-decoder": {
-      "version": "0.7.11",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@wasm-audio-decoders/common": "9.0.7"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/eshaz"
       }
     },
     "node_modules/p-finally": {
@@ -11218,14 +11114,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/qoa-format": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@thi.ng/bitstream": "^2.2.12"
-      }
-    },
     "node_modules/qrcode-terminal": {
       "version": "0.12.0",
       "bin": {
@@ -11330,7 +11218,6 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11426,6 +11313,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/seltz": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/seltz/-/seltz-1.0.0.tgz",
+      "integrity": "sha512-ahE/2wWHIwK26Aixwqbl1SFhyBIqAQ0n9veRzFqAo4X/+ebMggn7som1HIlin0qk9yYfLDyzzhYVs69qWSWrew==",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.0.0",
+        "@grpc/grpc-js": "^1.12.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "dev": true,
@@ -11438,6 +11338,7 @@
       "version": "0.34.5",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -11479,6 +11380,7 @@
     "node_modules/sharp/node_modules/semver": {
       "version": "7.7.3",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -11549,15 +11451,6 @@
     "node_modules/simple-wcswidth": {
       "version": "1.1.2",
       "license": "MIT"
-    },
-    "node_modules/simple-yenc": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/eshaz"
-      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -11639,7 +11532,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -11918,7 +11810,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12113,7 +12004,6 @@
     "node_modules/ws": {
       "version": "8.18.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -12132,7 +12022,6 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -12145,7 +12034,6 @@
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -12162,7 +12050,6 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -12170,7 +12057,6 @@
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -12183,12 +12069,10 @@
     },
     "node_modules/yargs/node_modules/string-width/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12208,7 +12092,6 @@
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "linkedom": "^0.18.12",
     "playwright": "^1.58.2",
     "qrcode-terminal": "^0.12.0",
+    "seltz": "^1.0.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,6 +1,6 @@
 import { StructuredToolInterface } from '@langchain/core/tools';
 import { createGetFinancials, createGetMarketData, createReadFilings, createScreenStocks } from './finance/index.js';
-import { exaSearch, perplexitySearch, tavilySearch, WEB_SEARCH_DESCRIPTION, xSearchTool, X_SEARCH_DESCRIPTION } from './search/index.js';
+import { exaSearch, perplexitySearch, seltzSearch, tavilySearch, WEB_SEARCH_DESCRIPTION, xSearchTool, X_SEARCH_DESCRIPTION } from './search/index.js';
 import { skillTool, SKILL_TOOL_DESCRIPTION } from './skill.js';
 import { webFetchTool, WEB_FETCH_DESCRIPTION } from './fetch/web-fetch.js';
 import { browserTool, BROWSER_DESCRIPTION } from './browser/browser.js';
@@ -141,7 +141,7 @@ export function getToolRegistry(model: string): RegisteredTool[] {
     },
   ];
 
-  // Include web_search if Exa, Perplexity, or Tavily API key is configured (Exa → Perplexity → Tavily)
+  // Include web_search if a search API key is configured (Exa → Perplexity → Seltz → Tavily)
   if (process.env.EXASEARCH_API_KEY) {
     tools.push({
       name: 'web_search',
@@ -156,6 +156,14 @@ export function getToolRegistry(model: string): RegisteredTool[] {
       tool: perplexitySearch,
       description: WEB_SEARCH_DESCRIPTION,
       compactDescription: 'Search the web for current information. Returns an answer with citations.',
+      concurrencySafe: true,
+    });
+  } else if (process.env.SELTZ_API_KEY) {
+    tools.push({
+      name: 'web_search',
+      tool: seltzSearch,
+      description: WEB_SEARCH_DESCRIPTION,
+      compactDescription: 'Search the web for current information. Returns URLs and LLM-optimized content.',
       concurrencySafe: true,
     });
   } else if (process.env.TAVILY_API_KEY) {

--- a/src/tools/search/index.ts
+++ b/src/tools/search/index.ts
@@ -29,4 +29,5 @@ Search the web for current information on any topic. Returns relevant search res
 export { tavilySearch } from './tavily.js';
 export { exaSearch } from './exa.js';
 export { perplexitySearch } from './perplexity.js';
+export { seltzSearch } from './seltz.js';
 export { xSearchTool, X_SEARCH_DESCRIPTION } from './x-search.js';

--- a/src/tools/search/seltz.ts
+++ b/src/tools/search/seltz.ts
@@ -1,0 +1,37 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { Seltz } from 'seltz';
+import { z } from 'zod';
+import { formatToolResult } from '../types.js';
+import { logger } from '../../utils/logger.js';
+
+// Lazily initialized to avoid errors when API key is not set
+let seltzClient: Seltz | null = null;
+
+function getSeltzClient(): Seltz {
+  if (!seltzClient) {
+    seltzClient = new Seltz();
+  }
+  return seltzClient;
+}
+
+export const seltzSearch = new DynamicStructuredTool({
+  name: 'web_search',
+  description:
+    'Search the web for current information on any topic. Returns relevant search results with URLs and content snippets.',
+  schema: z.object({
+    query: z.string().describe('The search query to look up on the web'),
+  }),
+  func: async (input) => {
+    try {
+      const result = await getSeltzClient().search(input.query, 5);
+      const urls = result.documents
+        ?.map((doc) => doc.url)
+        .filter((url): url is string => Boolean(url)) ?? [];
+      return formatToolResult(result, urls);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`[Seltz API] error: ${message}`);
+      throw new Error(`[Seltz API] ${message}`);
+    }
+  },
+});


### PR DESCRIPTION
## Summary
- Add [Seltz](https://www.seltz.ai/) as a new web search provider, slotting it between Perplexity and Tavily in the fallback chain (Exa → Perplexity → **Seltz** → Tavily)
- New `seltz` npm dependency (`^1.0.0`) using gRPC transport
- Enabled via `SELTZ_API_KEY` environment variable

## Changes
- `src/tools/search/seltz.ts` — new search tool implementation using the Seltz SDK
- `src/tools/search/index.ts` — re-export `seltzSearch`
- `src/tools/registry.ts` — register Seltz in the provider fallback chain
- `env.example` — document `SELTZ_API_KEY`
- `package.json` / `package-lock.json` — add `seltz` dependency

## Test plan
- [x] Set `SELTZ_API_KEY` and verify `web_search` tool uses Seltz
- [x] Verify fallback order: with no Exa/Perplexity key, Seltz is preferred over Tavily
- [x] Verify existing providers (Exa, Perplexity, Tavily) still work when their keys are set