### PR TITLE
fix(memory): avoid Bun Windows EEXIST on startup memory dir mkdir

### DIFF
--- a/src/memory/database.ts
+++ b/src/memory/database.ts
@@ -1,5 +1,5 @@
-import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
+import { ensureDirectory } from '../utils/ensure-directory.js';
 import type {
   MemoryChunk,
   MemoryKeywordCandidate,
@@ -117,7 +117,7 @@ export class MemoryDatabase {
   private constructor(private readonly db: SqliteDatabase) {}
 
   static async create(path: string): Promise<MemoryDatabase> {
-    await mkdir(dirname(path), { recursive: true });
+    await ensureDirectory(dirname(path));
     const db = await MemoryDatabase.openSqlite(path);
     const memoryDb = new MemoryDatabase(db);
     memoryDb.db.exec(CREATE_SCHEMA_SQL);

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -1,8 +1,9 @@
-import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { readdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join, normalize, relative } from 'node:path';
 import type { MemoryReadOptions, MemoryReadResult, MemorySessionContext } from './types.js';
 import { estimateTokens } from '../utils/tokens.js';
 import { getDexterDir } from '../utils/paths.js';
+import { ensureDirectory } from '../utils/ensure-directory.js';
 
 const MEMORY_DIRNAME = 'memory';
 const LONG_TERM_FILE = 'MEMORY.md';
@@ -36,7 +37,7 @@ export class MemoryStore {
   }
 
   async ensureDirectoryExists(): Promise<void> {
-    await mkdir(this.getMemoryDir(), { recursive: true });
+    await ensureDirectory(this.getMemoryDir());
   }
 
   async readMemoryFile(path: string): Promise<string> {
@@ -50,7 +51,7 @@ export class MemoryStore {
 
   async writeMemoryFile(path: string, content: string): Promise<void> {
     const resolved = this.resolveMemoryPath(path);
-    await mkdir(dirname(resolved), { recursive: true });
+    await ensureDirectory(dirname(resolved));
     await writeFile(resolved, content, 'utf-8');
   }
 

--- a/src/utils/ensure-directory.test.ts
+++ b/src/utils/ensure-directory.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ensureDirectory } from './ensure-directory.js';
+
+describe('ensureDirectory', () => {
+  let rootDir: string;
+
+  beforeEach(() => {
+    rootDir = mkdtempSync(join(tmpdir(), 'dexter-ensure-dir-'));
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  test('succeeds when the directory already exists', async () => {
+    const dir = join(rootDir, 'memory');
+    mkdirSync(dir, { recursive: true });
+
+    await expect(ensureDirectory(dir)).resolves.toBeUndefined();
+  });
+
+  test('creates missing nested directories', async () => {
+    const dir = join(rootDir, '.dexter', 'memory', 'nested');
+
+    await expect(ensureDirectory(dir)).resolves.toBeUndefined();
+  });
+
+  test('throws when path exists as a file', async () => {
+    const filePath = join(rootDir, 'not-a-dir');
+    writeFileSync(filePath, 'x');
+
+    await expect(ensureDirectory(filePath)).rejects.toThrow();
+  });
+});

--- a/src/utils/ensure-directory.ts
+++ b/src/utils/ensure-directory.ts
@@ -1,0 +1,24 @@
+import { mkdir, stat } from 'node:fs/promises';
+
+type NodeErrorWithCode = Error & { code?: string };
+
+/**
+ * Work around Bun-on-Windows mkdir recursive EEXIST behavior by accepting
+ * EEXIST only when the target already exists as a directory.
+ */
+export async function ensureDirectory(path: string): Promise<void> {
+  try {
+    await mkdir(path, { recursive: true });
+    return;
+  } catch (error) {
+    const err = error as NodeErrorWithCode;
+    if (err.code !== 'EEXIST') {
+      throw error;
+    }
+    const existing = await stat(path).catch(() => null);
+    if (existing?.isDirectory()) {
+      return;
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a shared `ensureDirectory()` helper that safely handles Bun-on-Windows `mkdir(..., { recursive: true })` throwing `EEXIST` for already-existing directories
- use this helper in memory initialization/write paths:
  - `MemoryStore.ensureDirectoryExists()`
  - `MemoryStore.writeMemoryFile()` parent directory creation
  - `MemoryDatabase.create()` parent directory creation
- add regression tests for `ensureDirectory()` behavior when target already exists, is missing, and is a file

## Why
Issue #242 reports:
- `Error: EEXIST: file already exists, mkdir '.dexter\\memory'`

Dexter currently calls recursive mkdir on startup for `.dexter/memory`. On affected Bun/Windows versions, this can throw `EEXIST` even when the directory already exists, causing memory initialization to fail before the existing fallback handling.

## Validation
- static review of affected call sites completed
- unable to execute `bun run typecheck` / `bun test` in this cloud environment because `bun` is not installed (`bun: command not found`)

## Risk
Low. Changes are limited to directory creation behavior and preserve existing failure semantics for non-directory collisions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0fc0e75-1b62-47df-a592-48aa1ce2e23c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0fc0e75-1b62-47df-a592-48aa1ce2e23c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

