### PR TITLE
fix(cron): replace  z.discriminatedUnion with z.union for Gemini compability

### DIFF
--- a/src/tools/cron/cron-tool.ts
+++ b/src/tools/cron/cron-tool.ts
@@ -51,18 +51,18 @@ Write it as a clear instruction, e.g.: "Check the current price of AAPL. If it h
 - Minimum interval for "every" schedules is 60 seconds
 `.trim();
 
-const scheduleSchema = z.discriminatedUnion('kind', [
+const scheduleSchema = z.union([
   z.object({
-    kind: z.literal('at'),
+    kind: z.enum(['at']),
     at: z.string().describe('ISO-8601 timestamp for one-shot execution'),
   }),
   z.object({
-    kind: z.literal('every'),
+    kind: z.enum(['every']),
     everyMs: z.number().min(60000).describe('Interval in milliseconds (minimum 60000 = 1 minute)'),
     anchorMs: z.number().optional().describe('Optional anchor timestamp in ms'),
   }),
   z.object({
-    kind: z.literal('cron'),
+    kind: z.enum(['cron']),
     expr: z.string().describe('Cron expression (5 or 6 fields)'),
     tz: z.string().optional().describe('IANA timezone (default: system timezone)'),
   }),


### PR DESCRIPTION
**Fix Gemini API compatibility with `z.discriminatedUnion`**

## Problem

Google's Gemini API rejects tool schemas that use the JSON Schema `const` keyword. The `z.discriminatedUnion` with `z.literal()` in the cron tool schema generates `const` in the JSON Schema, causing:

```
400 Bad Request Invalid JSON payload received. Unknown name "const" at 'tools[0].function_declarations[10].parameters.properties[3].value.oneOf...'
```

## Solution

Replace `z.discriminatedUnion` with `z.union` and `z.literal` with `z.enum` in `src/tools/cron/cron-tool.ts`. This generates `{ "enum": ["at"] }` instead of `{ "const": "at" }`, which Gemini accepts while preserving the same runtime validation.

## Changes

- `src/tools/cron/cron-tool.ts`: Use `z.union` + `z.enum` instead of `z.discriminatedUnion` + `z.literal` for schedule schema

## Verification

- `bun run typecheck` passes
- `bun test` passes (37/37)