### PR TITLE
fix: waiting for approval when creating rules

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -196,6 +196,7 @@ export async function runCli() {
   let lastRenderedAnswer = false;
   let lastRenderedQueryId: string | null = null;
   const finalizedToolIds = new Set<string>();
+  let lastPendingApproval: { tool: string; args: Record<string, unknown> } | null = null;
 
   agentRunner = new AgentRunnerController(
     { model: modelSelection.model, modelProvider: modelSelection.provider, maxIterations: 10 },
@@ -260,6 +261,10 @@ export async function runCli() {
 
       workingIndicator.setState(agentRunner.workingState);
       updateView();
+      if (agentRunner.pendingApproval !== lastPendingApproval) {
+        lastPendingApproval = agentRunner.pendingApproval;
+        renderSelectionOverlay();
+      }
       throttledRender();
     },
   );

--- a/src/controllers/agent-runner.test.ts
+++ b/src/controllers/agent-runner.test.ts
@@ -1,13 +1,67 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, test, mock, beforeEach, afterEach } from 'bun:test';
 import { AgentRunnerController } from './agent-runner.js';
 import { InMemoryChatHistory } from '../utils/in-memory-chat-history.js';
+import type { AgentConfig, AgentEvent, ApprovalDecision } from '../agent/types.js';
+
+/**
+ * Helper to create an AgentRunnerController with a change counter
+ */
+function createController(onChange?: () => void) {
+  let changeCount = 0;
+  const controller = new AgentRunnerController(
+    { model: 'gpt-5.4', modelProvider: 'openai', maxIterations: 10 },
+    new InMemoryChatHistory('gpt-5.4'),
+    () => {
+      changeCount++;
+      onChange?.();
+    },
+  );
+  return { controller, getChangeCount: () => changeCount };
+}
 
 describe('AgentRunnerController', () => {
+  let capturedApprovalRequest: { tool: string; args: Record<string, unknown> } | null = null;
+  let capturedApprovalResolve: ((decision: ApprovalDecision) => void) | null = null;
+  let mockAgentRunYielded: AgentEvent[] = [];
+
+  beforeEach(() => {
+    capturedApprovalRequest = null;
+    capturedApprovalResolve = null;
+    mockAgentRunYielded = [];
+
+    mock.module('../agent/agent.js', () => ({
+      Agent: class MockAgent {
+        static async create(config: AgentConfig) {
+          return new MockAgent(config);
+        }
+
+        constructor(private config: AgentConfig) {}
+
+        async *run(): AsyncGenerator<AgentEvent> {
+          // Capture the approval request function from config
+          const requestApproval = this.config.requestToolApproval;
+          if (requestApproval) {
+            const promise = requestApproval({ tool: 'write_file', args: { path: '.dexter/RULES.md', content: 'test' } });
+            promise.then(() => {});
+          }
+
+          // Yield any configured events
+          for (const event of mockAgentRunYielded) {
+            yield event;
+          }
+
+          yield { type: 'done', answer: 'done', toolCalls: [], iterations: 1, totalTime: 100 };
+        }
+      },
+    }));
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
   test('updates the active agent config for subsequent runs', () => {
-    const controller = new AgentRunnerController(
-      { model: 'gpt-5.4', modelProvider: 'openai', maxIterations: 10 },
-      new InMemoryChatHistory('gpt-5.4'),
-    );
+    const { controller } = createController();
 
     controller.updateAgentConfig({
       model: 'ollama:llama3.1',
@@ -18,6 +72,185 @@ describe('AgentRunnerController', () => {
       model: 'ollama:llama3.1',
       modelProvider: 'ollama',
       maxIterations: 10,
+    });
+  });
+
+  describe('approval state', () => {
+    test('sets pendingApproval when entering approval state', async () => {
+      const { controller } = createController();
+
+      expect(controller.pendingApproval).toBeNull();
+
+      const runPromise = controller.runQuery('test query');
+
+      // Wait a tick for the async agent.run() to start
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(controller.pendingApproval).not.toBeNull();
+      expect(controller.pendingApproval?.tool).toBe('write_file');
+      expect(controller.pendingApproval?.args).toMatchObject({
+        path: '.dexter/RULES.md',
+        content: 'test',
+      });
+
+      // Clean up: deny to complete the run
+      controller.respondToApproval('deny');
+      await runPromise;
+    });
+
+    test('fires onChange when entering approval state', async () => {
+      const { controller, getChangeCount } = createController();
+      const initialCount = getChangeCount();
+
+      const runPromise = controller.runQuery('test query');
+
+      // Wait a tick for the async agent.run() to start
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(getChangeCount()).toBeGreaterThan(initialCount);
+
+      // Clean up: deny to complete the run
+      controller.respondToApproval('deny');
+      await runPromise;
+    });
+
+    test('clears pendingApproval on allow-once', async () => {
+      const { controller } = createController();
+
+      const runPromise = controller.runQuery('test query');
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(controller.pendingApproval).not.toBeNull();
+
+      controller.respondToApproval('allow-once');
+      await runPromise;
+
+      expect(controller.pendingApproval).toBeNull();
+    });
+
+    test('clears pendingApproval on deny', async () => {
+      const { controller } = createController();
+
+      const runPromise = controller.runQuery('test query');
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(controller.pendingApproval).not.toBeNull();
+
+      controller.respondToApproval('deny');
+      await runPromise;
+
+      expect(controller.pendingApproval).toBeNull();
+    });
+
+    test('fires onChange when exiting approval state', async () => {
+      const { controller, getChangeCount } = createController();
+
+      const runPromise = controller.runQuery('test query');
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const countAfterEnter = getChangeCount();
+
+      controller.respondToApproval('allow-once');
+      await runPromise;
+
+      expect(getChangeCount()).toBeGreaterThan(countAfterEnter);
+    });
+
+    test('fires onChange when exiting approval state via deny', async () => {
+      const { controller, getChangeCount } = createController();
+
+      const runPromise = controller.runQuery('test query');
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const countAfterEnter = getChangeCount();
+
+      controller.respondToApproval('deny');
+      await runPromise;
+
+      expect(getChangeCount()).toBeGreaterThan(countAfterEnter);
+    });
+  });
+
+  describe('cancelExecution', () => {
+    test('clears pendingApproval', async () => {
+      const { controller } = createController();
+
+      const runPromise = controller.runQuery('test query');
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(controller.pendingApproval).not.toBeNull();
+
+      controller.cancelExecution();
+      await runPromise;
+
+      expect(controller.pendingApproval).toBeNull();
+    });
+
+    test('fires onChange', async () => {
+      const { controller, getChangeCount } = createController();
+
+      const runPromise = controller.runQuery('test query');
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const countBeforeCancel = getChangeCount();
+
+      controller.cancelExecution();
+      await runPromise;
+
+      expect(getChangeCount()).toBeGreaterThan(countBeforeCancel);
+    });
+
+    test('sets workingState to idle', async () => {
+      const { controller } = createController();
+
+      const runPromise = controller.runQuery('test query');
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(controller.workingState.status).toBe('approval');
+
+      controller.cancelExecution();
+      await runPromise;
+
+      expect(controller.workingState.status).toBe('idle');
+    });
+  });
+
+  describe('respondToApproval edge cases', () => {
+    test('does nothing when no approval is pending', () => {
+      const { controller, getChangeCount } = createController();
+      const countBefore = getChangeCount();
+
+      // Should not throw and should not fire onChange
+      controller.respondToApproval('allow-once');
+
+      expect(getChangeCount()).toBe(countBefore);
+    });
+
+    test('updates workingState to thinking on allow-once', async () => {
+      const { controller } = createController();
+
+      const runPromise = controller.runQuery('test query');
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(controller.workingState.status).toBe('approval');
+
+      controller.respondToApproval('allow-once');
+      await runPromise;
+
+      // After respondToApproval('allow-once'), workingState should be 'thinking'
+      expect(controller.workingState.status).toBe('idle'); // idle after run completes
+    });
+
+    test('keeps workingState idle on deny', async () => {
+      const { controller } = createController();
+
+      const runPromise = controller.runQuery('test query');
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      controller.respondToApproval('deny');
+      await runPromise;
+
+      expect(controller.workingState.status).toBe('idle');
     });
   });
 });

--- a/src/controllers/agent-runner.test.ts
+++ b/src/controllers/agent-runner.test.ts
@@ -42,7 +42,7 @@ describe('AgentRunnerController', () => {
           const requestApproval = this.config.requestToolApproval;
           if (requestApproval) {
             const promise = requestApproval({ tool: 'write_file', args: { path: '.dexter/RULES.md', content: 'test' } });
-            promise.then(() => {});
+            await promise;
           }
 
           // Yield any configured events

--- a/src/controllers/agent-runner.test.ts
+++ b/src/controllers/agent-runner.test.ts
@@ -20,13 +20,9 @@ function createController(onChange?: () => void) {
 }
 
 describe('AgentRunnerController', () => {
-  let capturedApprovalRequest: { tool: string; args: Record<string, unknown> } | null = null;
-  let capturedApprovalResolve: ((decision: ApprovalDecision) => void) | null = null;
   let mockAgentRunYielded: AgentEvent[] = [];
 
   beforeEach(() => {
-    capturedApprovalRequest = null;
-    capturedApprovalResolve = null;
     mockAgentRunYielded = [];
 
     mock.module('../agent/agent.js', () => ({
@@ -237,8 +233,8 @@ describe('AgentRunnerController', () => {
       controller.respondToApproval('allow-once');
       await runPromise;
 
-      // After respondToApproval('allow-once'), workingState should be 'thinking'
-      expect(controller.workingState.status).toBe('idle'); // idle after run completes
+      // After run completes, workingState returns to idle
+      expect(controller.workingState.status).toBe('idle');
     });
 
     test('keeps workingState idle on deny', async () => {

--- a/src/controllers/agent-runner.test.ts
+++ b/src/controllers/agent-runner.test.ts
@@ -9,8 +9,8 @@ import type { AgentConfig, AgentEvent, ApprovalDecision } from '../agent/types.j
 function createController(onChange?: () => void) {
   let changeCount = 0;
   const controller = new AgentRunnerController(
-    { model: 'gpt-5.4', modelProvider: 'openai', maxIterations: 10 },
-    new InMemoryChatHistory('gpt-5.4'),
+    { model: 'gpt-5.5', modelProvider: 'openai', maxIterations: 10 },
+    new InMemoryChatHistory('gpt-5.5'),
     () => {
       changeCount++;
       onChange?.();


### PR DESCRIPTION
**Fix approval prompt not rendering when creating rules**

### Problem
When the agent requested approval for file-modifying tools (e.g., `write_file` to create `.dexter/RULES.md`), the CLI showed "Waiting for approval..." but never rendered the actual approval overlay with selectable options. Pressing Enter had no effect because the approval prompt was never displayed.

### Root Cause
`renderSelectionOverlay()` was only called from the model selection callback and startup — never from the agent runner's `onChange`. When the agent entered approval state, the working indicator updated but the overlay wasn't triggered.

### Fix
Added `lastPendingApproval` state tracking in the `onChange` callback (`src/cli.ts`). When `pendingApproval` transitions (enters or exits), `renderSelectionOverlay()` is now called to properly show/hide the approval overlay.

### Tests
Added 12 unit tests in `src/controllers/agent-runner.test.ts` covering:
- Approval state transitions (enter/exit)
- `onChange` firing during approval state changes
- `cancelExecution` behavior
- Edge cases (no-op when no approval pending)

### Files Changed
- `src/cli.ts` - Track `pendingApproval` changes and trigger overlay rendering
- `src/controllers/agent-runner.test.ts` - 12 new tests for approval state management

Resolves: #245