### PR TITLE
fix: select default model from configured provider

### DIFF
--- a/src/controllers/model-selection.test.ts
+++ b/src/controllers/model-selection.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ModelSelectionController } from './model-selection.js';
+import { saveConfig } from '../utils/config.js';
+
+const PROVIDER_API_KEY_ENV_VARS = [
+  'OPENAI_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'GOOGLE_API_KEY',
+  'XAI_API_KEY',
+  'MOONSHOT_API_KEY',
+  'DEEPSEEK_API_KEY',
+  'OPENROUTER_API_KEY',
+];
+
+describe('ModelSelectionController', () => {
+  const originalCwd = process.cwd();
+  let tempDir = '';
+  let originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'dexter-model-selection-'));
+    process.chdir(tempDir);
+    originalEnv = {};
+
+    for (const key of PROVIDER_API_KEY_ENV_VARS) {
+      originalEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+
+    for (const key of PROVIDER_API_KEY_ENV_VARS) {
+      const original = originalEnv[key];
+      if (original === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original;
+      }
+    }
+
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('uses the first configured provider when no model settings exist', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key';
+
+    const controller = new ModelSelectionController(() => {});
+
+    expect(controller.provider).toBe('anthropic');
+    expect(controller.model).toBe('claude-sonnet-4-6');
+  });
+
+  test('ignores placeholder API keys when detecting the initial provider', () => {
+    process.env.OPENAI_API_KEY = 'your-openai-api-key';
+    process.env.GOOGLE_API_KEY = 'test-google-key';
+
+    const controller = new ModelSelectionController(() => {});
+
+    expect(controller.provider).toBe('google');
+    expect(controller.model).toBe('gemini-3-flash-preview');
+  });
+
+  test('keeps saved settings ahead of environment auto-detection', () => {
+    saveConfig({ provider: 'openai', modelId: 'gpt-5.5' });
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key';
+
+    const controller = new ModelSelectionController(() => {});
+
+    expect(controller.provider).toBe('openai');
+    expect(controller.model).toBe('gpt-5.5');
+  });
+});

--- a/src/controllers/model-selection.ts
+++ b/src/controllers/model-selection.ts
@@ -5,8 +5,8 @@ import {
   saveApiKeyForProvider,
 } from '../utils/env.js';
 import {
-  getDefaultModelForProvider,
   getModelsForProvider,
+  resolveInitialModelSelection,
   type Model,
 } from '../utils/model.js';
 import { getOllamaModels } from '../utils/ollama.js';
@@ -46,10 +46,16 @@ export class ModelSelectionController {
   constructor(onError: (message: string) => void, onChange?: ChangeListener) {
     this.onError = onError;
     this.onChange = onChange;
-    this.providerValue = getSetting('provider', DEFAULT_PROVIDER);
+    const savedProvider = getSetting('provider', null) as string | null;
     const savedModel = getSetting('modelId', null) as string | null;
-    this.modelValue =
-      savedModel ?? getDefaultModelForProvider(this.providerValue) ?? DEFAULT_MODEL;
+    const initial = resolveInitialModelSelection({
+      savedProvider,
+      savedModel,
+      defaultProvider: DEFAULT_PROVIDER,
+      defaultModel: DEFAULT_MODEL,
+    });
+    this.providerValue = initial.provider;
+    this.modelValue = initial.model;
     this.chatHistory.setModel(this.modelValue);
   }
 

--- a/src/cron/executor.ts
+++ b/src/cron/executor.ts
@@ -9,6 +9,7 @@ import { assertOutboundAllowed, sendMessageWhatsApp } from '../gateway/channels/
 import { resolveSessionStorePath, loadSessionStore, type SessionEntry } from '../gateway/sessions/store.js';
 import { cleanMarkdownForWhatsApp } from '../gateway/utils.js';
 import { getSetting } from '../utils/config.js';
+import { resolveInitialModelSelection } from '../utils/model.js';
 import { dexterPath } from '../utils/paths.js';
 import { saveCronStore } from './store.js';
 import { computeNextRunAtMs } from './schedule.js';
@@ -125,8 +126,14 @@ export async function executeCronJob(
   }
 
   // 3. Resolve model
-  const model = job.payload.model ?? (getSetting('modelId', 'gpt-5.5') as string);
-  const modelProvider = job.payload.modelProvider ?? (getSetting('provider', 'openai') as string);
+  const initialModel = resolveInitialModelSelection({
+    savedModel: getSetting('modelId', null) as string | null,
+    savedProvider: getSetting('provider', null) as string | null,
+    defaultModel: 'gpt-5.5',
+    defaultProvider: 'openai',
+  });
+  const model = job.payload.model ?? initialModel.model;
+  const modelProvider = job.payload.modelProvider ?? initialModel.provider;
 
   // 4. Build query
   let query = `[CRON JOB: ${job.name}]\n\n${job.payload.message}`;

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -25,6 +25,7 @@ import type { GroupContext } from '../agent/prompts.js';
 import { appendFileSync } from 'node:fs';
 import { dexterPath } from '../utils/paths.js';
 import { getSetting } from '../utils/config.js';
+import { resolveInitialModelSelection } from '../utils/model.js';
 
 const LOG_PATH = dexterPath('gateway-debug.log');
 function debugLog(msg: string) {
@@ -157,8 +158,12 @@ async function handleInbound(cfg: GatewayConfig, inbound: WhatsAppInboundMessage
     }
 
     console.log(`Processing message with agent...`);
-    const model = getSetting('modelId', 'gpt-5.5') as string;
-    const modelProvider = getSetting('provider', 'openai') as string;
+    const { model, provider: modelProvider } = resolveInitialModelSelection({
+      savedModel: getSetting('modelId', null) as string | null,
+      savedProvider: getSetting('provider', null) as string | null,
+      defaultModel: 'gpt-5.5',
+      defaultProvider: 'openai',
+    });
 
     // If agent is already running for this session, enqueue for mid-run injection
     if (isSessionRunning(route.sessionKey)) {
@@ -238,4 +243,3 @@ export async function startGateway(params: { configPath?: string } = {}): Promis
     snapshot: () => manager.getSnapshot(),
   };
 }
-

--- a/src/model/llm.test.ts
+++ b/src/model/llm.test.ts
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { getChatModel } from './llm.js';
+
+describe('getChatModel', () => {
+  const originalOpenAiKey = process.env.OPENAI_API_KEY;
+
+  afterEach(() => {
+    if (originalOpenAiKey === undefined) {
+      delete process.env.OPENAI_API_KEY;
+    } else {
+      process.env.OPENAI_API_KEY = originalOpenAiKey;
+    }
+  });
+
+  test('rejects placeholder API keys before creating an OpenAI client', () => {
+    process.env.OPENAI_API_KEY = 'your-openai-api-key';
+
+    expect(() => getChatModel('gpt-5.5')).toThrow(/OPENAI_API_KEY is not set/);
+  });
+});

--- a/src/model/llm.ts
+++ b/src/model/llm.ts
@@ -14,6 +14,7 @@ import type { TokenUsage } from '@/agent/types';
 import { logger } from '@/utils';
 import { classifyError, isNonRetryableError } from '@/utils/errors';
 import { resolveProvider, getProviderById } from '@/providers';
+import { isUsableApiKeyValue } from '@/utils/env';
 
 export const DEFAULT_PROVIDER = 'openai';
 export const DEFAULT_MODEL = 'gpt-5.5';
@@ -58,10 +59,12 @@ type ModelFactory = (name: string, opts: ModelOpts) => BaseChatModel;
 
 function getApiKey(envVar: string): string {
   const apiKey = process.env[envVar];
-  if (!apiKey) {
-    throw new Error(`[LLM] ${envVar} not found in environment variables`);
+  if (!isUsableApiKeyValue(apiKey)) {
+    throw new Error(
+      `[LLM] ${envVar} is not set. Set ${envVar} or use /model to select a configured provider.`,
+    );
   }
-  return apiKey;
+  return apiKey.trim();
 }
 
 // Factories keyed by provider id — prefix routing is handled by resolveProvider()

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -19,9 +19,14 @@ export function checkApiKeyExistsForProvider(providerId: string): boolean {
   return checkApiKeyExists(apiKeyName);
 }
 
+export function isUsableApiKeyValue(value: string | undefined): value is string {
+  const trimmed = value?.trim();
+  return !!trimmed && !trimmed.toLowerCase().startsWith('your-');
+}
+
 export function checkApiKeyExists(apiKeyName: string): boolean {
   const value = process.env[apiKeyName];
-  if (value && value.trim() && !value.trim().startsWith('your-')) {
+  if (isUsableApiKeyValue(value)) {
     return true;
   }
 
@@ -35,7 +40,7 @@ export function checkApiKeyExists(apiKeyName: string): boolean {
         const [key, ...valueParts] = trimmed.split('=');
         if (key.trim() === apiKeyName) {
           const val = valueParts.join('=').trim();
-          if (val && !val.startsWith('your-')) {
+          if (isUsableApiKeyValue(val)) {
             return true;
           }
         }

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -1,4 +1,5 @@
-import { PROVIDERS as PROVIDER_DEFS } from '@/providers';
+import { PROVIDERS as PROVIDER_DEFS, resolveProvider } from '@/providers';
+import { checkApiKeyExistsForProvider } from './env.js';
 
 export interface Model {
   id: string;
@@ -53,6 +54,35 @@ export function getModelIdsForProvider(providerId: string): string[] {
 export function getDefaultModelForProvider(providerId: string): string | undefined {
   const models = getModelsForProvider(providerId);
   return models[0]?.id;
+}
+
+export function getFirstProviderWithApiKey(): string | undefined {
+  return PROVIDER_DEFS.find((provider) =>
+    provider.apiKeyEnvVar ? checkApiKeyExistsForProvider(provider.id) : false,
+  )?.id;
+}
+
+export interface InitialModelSelectionOptions {
+  savedProvider?: string | null;
+  savedModel?: string | null;
+  defaultProvider: string;
+  defaultModel: string;
+}
+
+export function resolveInitialModelSelection({
+  savedProvider,
+  savedModel,
+  defaultProvider,
+  defaultModel,
+}: InitialModelSelectionOptions): { provider: string; model: string } {
+  const provider =
+    savedProvider ??
+    (savedModel ? resolveProvider(savedModel).id : undefined) ??
+    getFirstProviderWithApiKey() ??
+    defaultProvider;
+  const model = savedModel ?? getDefaultModelForProvider(provider) ?? defaultModel;
+
+  return { provider, model };
 }
 
 export function getModelDisplayName(modelId: string): string {


### PR DESCRIPTION
## Summary
- Auto-select the initial model/provider from the first configured API key when no saved settings exist
- Treat env.example-style `your-*` placeholders as missing API keys before constructing LLM clients
- Reuse the same initial model selection for CLI, WhatsApp gateway, and cron jobs
- Add regression tests for provider auto-detection and placeholder OpenAI keys

Resolves #241

## Testing
- `bun test src/controllers/model-selection.test.ts src/model/llm.test.ts`
- `bun run typecheck`
- `bun test`