### PR TITLE
fix(screener): remove .default() from currency/limit to fix OpenAI strict schema error

### DIFF
--- a/src/tools/finance/screen-stocks.ts
+++ b/src/tools/finance/screen-stocks.ts
@@ -56,8 +56,8 @@ const ScreenerFilterSchema = z.object({
     operator: z.enum(['gt', 'gte', 'lt', 'lte', 'eq', 'in']).describe('Comparison operator'),
     value: z.union([z.number(), z.string(), z.array(z.number()), z.array(z.string())]).describe('Numeric threshold, string for company fields (sector/industry), or array for "in" operator'),
   })).describe('Array of screening filters to apply'),
-  currency: z.string().default('USD').describe('Currency code (e.g., "USD")'),
-  limit: z.number().default(5).describe('Maximum number of results to return'),
+  currency: z.string().describe('Currency code (e.g., "USD")'),
+  limit: z.number().describe('Maximum number of results to return'),
 });
 
 type ScreenerFilters = z.infer<typeof ScreenerFilterSchema>;


### PR DESCRIPTION
With @langchain/openai@1.3.1 + zod@4.3.6, any field wrapped with .default()
in a schema passed as outputSchema gets converted by z.toJSONSchema({reused:'ref'})
into a $ref with sibling keywords (default/description/title).
OpenAI rejects this in strict structured-output mode with:

  400 $ref cannot have keywords {'default', 'description', 'title'}

This makes every stock_screener call fail with "Failed to parse screening criteria"
on gpt-4o / gpt-5.x models.

Fix: drop .default() from currency and limit — both fields remain required
in the strict schema, so behavior is unchanged.