### PR TITLE
fix(x-search): wait for rate-limit reset and retry instead of aborting

### DIFF
--- a/src/tools/search/x-search.test.ts
+++ b/src/tools/search/x-search.test.ts
@@ -1,0 +1,96 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { xApiGet } from './x-search.js';
+
+// Minimal Response stand-in for the fields xApiGet reads.
+function makeResponse(opts: {
+  status: number;
+  resetSec?: number;
+  body?: unknown;
+}): Response {
+  const headers = new Map<string, string>();
+  if (opts.resetSec !== undefined) {
+    headers.set(
+      'x-rate-limit-reset',
+      String(Math.floor(Date.now() / 1000) + opts.resetSec),
+    );
+  }
+  return {
+    status: opts.status,
+    ok: opts.status >= 200 && opts.status < 300,
+    headers: { get: (k: string) => headers.get(k.toLowerCase()) ?? null },
+    json: async () => opts.body ?? {},
+    text: async () => JSON.stringify(opts.body ?? {}),
+  } as unknown as Response;
+}
+
+const realFetch = globalThis.fetch;
+const realSetTimeout = globalThis.setTimeout;
+
+describe('xApiGet rate-limit handling', () => {
+  beforeEach(() => {
+    process.env.X_BEARER_TOKEN = 'test-token';
+    // Resolve sleep() instantly so retries don't add real wall-clock delay.
+    // @ts-expect-error - test stub
+    globalThis.setTimeout = (fn: () => void) => {
+      fn();
+      return 0;
+    };
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    globalThis.setTimeout = realSetTimeout;
+  });
+
+  test('waits for the reset window and retries after a 429', async () => {
+    const responses = [
+      makeResponse({ status: 429, resetSec: 1 }),
+      makeResponse({ status: 200, body: { data: [{ id: '1' }] } }),
+    ];
+    let calls = 0;
+    // @ts-expect-error - test stub
+    globalThis.fetch = async () => responses[calls++];
+
+    const result = await xApiGet('https://api.x.com/2/test');
+
+    expect(calls).toBe(2); // retried once after the 429
+    expect(result.data).toEqual([{ id: '1' }]);
+  });
+
+  test('throws after exhausting retries on repeated 429s', async () => {
+    let calls = 0;
+    // @ts-expect-error - test stub
+    globalThis.fetch = async () => {
+      calls++;
+      return makeResponse({ status: 429, resetSec: 1 });
+    };
+
+    await expect(xApiGet('https://api.x.com/2/test')).rejects.toThrow(
+      /rate limited/i,
+    );
+    // initial attempt + 3 retries
+    expect(calls).toBe(4);
+  });
+
+  test('does not wait when the reset window exceeds the cap', async () => {
+    let calls = 0;
+    let waited = false;
+    // @ts-expect-error - test stub
+    globalThis.setTimeout = (fn: () => void) => {
+      waited = true;
+      fn();
+      return 0;
+    };
+    // @ts-expect-error - test stub
+    globalThis.fetch = async () => {
+      calls++;
+      return makeResponse({ status: 429, resetSec: 3600 }); // 1h, beyond the cap
+    };
+
+    await expect(xApiGet('https://api.x.com/2/test')).rejects.toThrow(
+      /rate limited/i,
+    );
+    expect(calls).toBe(1); // threw immediately, no retry
+    expect(waited).toBe(false); // never slept
+  });
+});

--- a/src/tools/search/x-search.ts
+++ b/src/tools/search/x-search.ts
@@ -4,6 +4,8 @@ import { formatToolResult } from '../types.js';
 
 const X_API_BASE = 'https://api.x.com/2';
 const RATE_DELAY_MS = 350; // Delay between pagination requests to reduce rate-limit risk
+const MAX_RATE_LIMIT_RETRIES = 3; // How many times to wait-and-retry on HTTP 429
+const MAX_RATE_LIMIT_WAIT_MS = 60_000; // Don't wait longer than this for a reset window
 
 const TWEET_FIELDS =
   'tweet.fields=created_at,public_metrics,author_id,conversation_id,entities' +
@@ -44,7 +46,10 @@ async function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-async function xApiGet(url: string): Promise<RawXResponse> {
+export async function xApiGet(
+  url: string,
+  attempt = 0,
+): Promise<RawXResponse> {
   const res = await fetch(url, {
     headers: { Authorization: `Bearer ${getBearerToken()}` },
   });
@@ -54,6 +59,16 @@ async function xApiGet(url: string): Promise<RawXResponse> {
     const waitSec = reset
       ? Math.max(parseInt(reset) - Math.floor(Date.now() / 1000), 1)
       : 60;
+    const waitMs = waitSec * 1000;
+
+    // Wait for the rate-limit window to reset and retry instead of aborting
+    // mid-search. Bound both the wait and the retry count so an unusually long
+    // reset window can't hang the agent indefinitely.
+    if (attempt < MAX_RATE_LIMIT_RETRIES && waitMs <= MAX_RATE_LIMIT_WAIT_MS) {
+      await sleep(waitMs);
+      return xApiGet(url, attempt + 1);
+    }
+
     throw new Error(`X API rate limited. Resets in ${waitSec}s`);
   }
 


### PR DESCRIPTION
## Summary
Fixes #246. `xApiGet` in `x-search.ts` parsed the `X-Rate-Limit-Reset` header on a 429 but threw immediately, terminating multi-page searches mid-run. It now waits for the reset window and retries (up to 3×), bounded by a 60s cap so an unusually long reset window can't hang the agent.

## Changes
- Wait-and-retry on HTTP 429 instead of aborting; throw only after retries are exhausted or when the reset window exceeds the cap.
- Add unit tests covering retry-success, retry-exhaustion, and the over-cap fast-fail path.

## Testing
- `bun test` — 74 pass / 0 fail
- `tsc --noEmit` — clean