### PR TITLE
fix: formatter key mismatch, timer leak in withTimeout, truncation bug

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -506,14 +506,14 @@ export class Agent {
   }
 
   private truncateMessages(messages: BaseMessage[], keepRounds: number): number {
-    let roundStartIndex = 0;
+    let roundStartIndex = -1;
     for (let i = 0; i < messages.length; i++) {
       if (messages[i] instanceof AIMessage) {
         roundStartIndex = i;
         break;
       }
     }
-    if (roundStartIndex === 0) return 0;
+    if (roundStartIndex === -1) return 0;
 
     const rounds: { start: number; end: number }[] = [];
     let i = roundStartIndex;

--- a/src/tools/finance/formatters.ts
+++ b/src/tools/finance/formatters.ts
@@ -344,7 +344,7 @@ export const FINANCIAL_FORMATTERS: Record<string, (data: unknown, args?: Rec) =>
 };
 
 export const MARKET_DATA_FORMATTERS: Record<string, (data: unknown, args?: Rec) => string> = {
-  get_stock_price_snapshot: formatStockPrice,
+  get_stock_price: formatStockPrice,
   get_stock_prices: formatStockPrices,
   get_crypto_price_snapshot: formatCryptoPrice,
   get_crypto_prices: formatStockPrices,

--- a/src/tools/finance/utils.ts
+++ b/src/tools/finance/utils.ts
@@ -16,13 +16,14 @@ export const TTL_24H = 24 * 60 * 60 * 1000;
  * if the promise doesn't settle within `ms` milliseconds.
  */
 export function withTimeout<T>(promise: Promise<T>, ms: number, label?: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
   return Promise.race([
-    promise,
-    new Promise<never>((_, reject) =>
-      setTimeout(
+    promise.finally(() => clearTimeout(timer)),
+    new Promise<never>((_, reject) => {
+      timer = setTimeout(
         () => reject(new Error(`${label ?? 'Operation'} timed out after ${ms / 1000}s`)),
         ms,
-      ),
-    ),
+      );
+    }),
   ]);
 }

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -1,6 +1,5 @@
 /**
  * Async generator concurrency utilities.
- * Async generator concurrency helpers.
  */
 
 interface QueuedGenerator<A> {


### PR DESCRIPTION
Found a few bugs while reading through the codebase:

- \`MARKET_DATA_FORMATTERS\` had the key \`get_stock_price_snapshot\` but the actual tool is named \`get_stock_price\`, so \`formatStockPrice\` was never being called and stock price results were coming back as raw JSON
- \`withTimeout\` in finance/utils.ts wasn't clearing the setTimeout when the promise resolved successfully, so under heavy load with lots of parallel tool calls you'd accumulate orphaned timers
- \`truncateMessages\` used 0 as both "no AIMessage found" and "AIMessage at index 0", so when the first message was an AIMessage it would bail out instead of truncating. switched to -1 as the sentinel
- removed a duplicate line in the concurrency.ts JSDoc