### PR TITLE
feat: add Caesar as a web search provider

### DIFF
--- a/env.example
+++ b/env.example
@@ -18,11 +18,12 @@ OLLAMA_CLOUD_API_KEY=your-ollama-cloud-api-key
 # Stock Market API Key
 FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
 
-# Web Search API Keys (Exa → Perplexity → Tavily → LangSearch)
+# Web Search API Keys (Exa → Perplexity → Tavily → LangSearch → Caesar)
 EXASEARCH_API_KEY=your-exa-api-key
 PERPLEXITY_API_KEY=your-perplexity-api-key
 TAVILY_API_KEY=your-tavily-api-key
 LANGSEARCH_API_KEY=your-langsearch-api-key
+CAESAR_API_KEY=your-caesar-api-key
 
 # X/Twitter API (enables x_search tool for public sentiment research)
 X_BEARER_TOKEN=your-X-bearer-token

--- a/src/components/select-list.ts
+++ b/src/components/select-list.ts
@@ -56,21 +56,22 @@ export function createProviderSelector(
 
 export function createSearchProviderSelector(
   currentProvider: string,
-  onSelect: (providerId: 'exa' | 'perplexity' | 'tavily' | 'langsearch') => void,
+  onSelect: (providerId: 'exa' | 'perplexity' | 'tavily' | 'langsearch' | 'caesar') => void,
   onCancel: () => void,
 ) {
-  const providers: { id: 'exa' | 'perplexity' | 'tavily' | 'langsearch'; displayName: string }[] = [
+  const providers: { id: 'exa' | 'perplexity' | 'tavily' | 'langsearch' | 'caesar'; displayName: string }[] = [
     { id: 'exa', displayName: 'Exa' },
     { id: 'perplexity', displayName: 'Perplexity' },
     { id: 'tavily', displayName: 'Tavily' },
     { id: 'langsearch', displayName: 'LangSearch' },
+    { id: 'caesar', displayName: 'Caesar' },
   ];
   const items: SelectItem[] = providers.map((provider, index) => ({
     value: provider.id,
     label: `${index + 1}. ${provider.displayName}${currentProvider === provider.id ? ' ✓' : ''}`,
   }));
   const list = new VimSelectList(items, 5, selectListTheme);
-  list.onSelect = (item) => onSelect(item.value as 'exa' | 'perplexity' | 'tavily' | 'langsearch');
+  list.onSelect = (item) => onSelect(item.value as 'exa' | 'perplexity' | 'tavily' | 'langsearch' | 'caesar');
   list.onCancel = () => onCancel();
   return list;
 }

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,6 +1,6 @@
 import { StructuredToolInterface } from '@langchain/core/tools';
 import { createGetFinancials, createGetMarketData, createReadFilings, createScreenStocks } from './finance/index.js';
-import { exaSearch, perplexitySearch, tavilySearch, langSearch, WEB_SEARCH_DESCRIPTION, xSearchTool, X_SEARCH_DESCRIPTION } from './search/index.js';
+import { exaSearch, perplexitySearch, tavilySearch, langSearch, caesarSearch, WEB_SEARCH_DESCRIPTION, xSearchTool, X_SEARCH_DESCRIPTION } from './search/index.js';
 import { createWebSearchTool, type WebSearchProvider } from './search/web-search.js';
 import { getSetting } from '../utils/config.js';
 import type { SearchProviderId } from '../utils/env.js';
@@ -174,6 +174,9 @@ export function getToolRegistry(model: string): RegisteredTool[] {
   }
   if (process.env.LANGSEARCH_API_KEY) {
     allWebSearchProviders.push({ id: 'langsearch', name: 'LangSearch', tool: langSearch });
+  }
+  if (process.env.CAESAR_API_KEY) {
+    allWebSearchProviders.push({ id: 'caesar', name: 'Caesar', tool: caesarSearch });
   }
 
   if (allWebSearchProviders.length > 0) {

--- a/src/tools/search/caesar.test.ts
+++ b/src/tools/search/caesar.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { caesarSearch } from './caesar.js';
+
+const originalFetch = global.fetch;
+const originalKey = process.env.CAESAR_API_KEY;
+
+interface CapturedRequest {
+  url: string;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+function stubFetch(response: unknown, status = 200): CapturedRequest {
+  const captured: CapturedRequest = { url: '', headers: {}, body: undefined };
+  global.fetch = (async (url: string, init?: RequestInit) => {
+    captured.url = String(url);
+    captured.headers = (init?.headers as Record<string, string>) ?? {};
+    captured.body = init?.body ? JSON.parse(init.body as string) : undefined;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => response,
+      text: async () => JSON.stringify(response),
+    } as Response;
+  }) as typeof global.fetch;
+  return captured;
+}
+
+describe('caesarSearch', () => {
+  beforeEach(() => {
+    process.env.CAESAR_API_KEY = 'sk_live_test';
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    if (originalKey === undefined) {
+      delete process.env.CAESAR_API_KEY;
+    } else {
+      process.env.CAESAR_API_KEY = originalKey;
+    }
+  });
+
+  test('sends a Bearer header and maps results', async () => {
+    const captured = stubFetch({
+      results: [{ title: 'Rust runtimes', url: 'https://example.com/rust', snippet: 'tokio vs async-std' }],
+    });
+
+    const raw = await caesarSearch.invoke({ query: 'rust async runtime comparison' });
+
+    expect(captured.url).toBe('https://alpha.api.trycaesar.com/v1/search');
+    expect(captured.headers.Authorization).toBe('Bearer sk_live_test');
+    expect(captured.body).toEqual({ query: 'rust async runtime comparison', max_results: 5 });
+
+    const parsed = JSON.parse(raw as string);
+    expect(parsed.data.results[0]).toEqual({
+      title: 'Rust runtimes',
+      url: 'https://example.com/rust',
+      snippet: 'tokio vs async-std',
+    });
+    expect(parsed.sourceUrls).toEqual(['https://example.com/rust']);
+  });
+
+  test('throws when CAESAR_API_KEY is not set', async () => {
+    delete process.env.CAESAR_API_KEY;
+    stubFetch({ results: [] });
+
+    await expect(caesarSearch.invoke({ query: 'q' })).rejects.toThrow(/CAESAR_API_KEY is not set/);
+  });
+
+  test('prefers query-selected passages over the meta description', async () => {
+    stubFetch({
+      results: [
+        {
+          title: 'Tokio scheduler',
+          url: 'https://tokio.rs/blog/2019-10-scheduler',
+          // Caesar's `snippet` is the page's meta description, not query-relevant text.
+          snippet: 'A blog about the Tokio runtime.',
+          passages: [{ text: 'Work stealing balances load across worker threads.' }, { text: 'The new scheduler avoids the atomic increment in wake_by_ref.' }],
+          metadata: { published_at: '2019-10-13T00:00:00Z' },
+        },
+      ],
+    });
+
+    const parsed = JSON.parse((await caesarSearch.invoke({ query: 'q' })) as string);
+    const [result] = parsed.data.results;
+    expect(result.snippet).toBe(
+      'Work stealing balances load across worker threads.\n\nThe new scheduler avoids the atomic increment in wake_by_ref.',
+    );
+    expect(result.published).toBe('2019-10-13T00:00:00Z');
+  });
+
+  test('falls back to the snippet when a result has no passages', async () => {
+    stubFetch({ results: [{ title: 'A', url: 'https://a.test', snippet: 'only a snippet' }] });
+
+    const parsed = JSON.parse((await caesarSearch.invoke({ query: 'q' })) as string);
+    expect(parsed.data.results[0].snippet).toBe('only a snippet');
+    expect(parsed.data.results[0].published).toBeUndefined();
+  });
+
+  test('ignores empty passage text', async () => {
+    stubFetch({ results: [{ title: 'A', url: 'https://a.test', snippet: 'fallback', passages: [{ text: '   ' }] }] });
+
+    const parsed = JSON.parse((await caesarSearch.invoke({ query: 'q' })) as string);
+    expect(parsed.data.results[0].snippet).toBe('fallback');
+  });
+
+  test('tolerates alternate url/snippet field names', async () => {
+    stubFetch({
+      results: [
+        { title: 'A', canonical_url: 'https://a.test', content: 'body a' },
+        { title: 'B', source_url: 'https://b.test', passage: 'body b' },
+      ],
+    });
+
+    const parsed = JSON.parse((await caesarSearch.invoke({ query: 'q' })) as string);
+    expect(parsed.data.results).toEqual([
+      { title: 'A', url: 'https://a.test', snippet: 'body a' },
+      { title: 'B', url: 'https://b.test', snippet: 'body b' },
+    ]);
+    expect(parsed.sourceUrls).toEqual(['https://a.test', 'https://b.test']);
+  });
+
+  test('surfaces a clear error on 401', async () => {
+    process.env.CAESAR_API_KEY = 'sk_live_bad';
+    stubFetch({ error: 'invalid_api_key' }, 401);
+
+    await expect(caesarSearch.invoke({ query: 'q' })).rejects.toThrow(/Caesar API.*401/);
+  });
+});

--- a/src/tools/search/caesar.ts
+++ b/src/tools/search/caesar.ts
@@ -1,0 +1,99 @@
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { z } from 'zod';
+import { formatToolResult } from '../types.js';
+import { logger } from '@/utils';
+
+const CAESAR_API_URL = 'https://alpha.api.trycaesar.com/v1/search';
+
+interface CaesarPassage {
+  text?: string;
+}
+
+interface CaesarResult {
+  title?: string;
+  url?: string;
+  canonical_url?: string;
+  source_url?: string;
+  snippet?: string;
+  content?: string;
+  passage?: string;
+  // Extracts Caesar selected for this query, not a fixed chunking of the page.
+  passages?: CaesarPassage[];
+  metadata?: { published_at?: string | null };
+  // score is a scalar at default verbosity, { value } at higher verbosity
+  score?: number | { value?: number } | null;
+}
+
+interface CaesarResponse {
+  results?: CaesarResult[];
+}
+
+// Caesar returns both a `snippet` (the page's meta description) and `passages`
+// (spans it selected for this query). Prefer the passages: they carry the text
+// that actually answers the query, so the agent rarely needs to fetch the page.
+// Mirrors how the LangSearch provider prefers `summary` over its short `snippet`.
+function contentFor(r: CaesarResult): string | undefined {
+  const passages = (r.passages ?? []).map((p) => p.text?.trim()).filter((t): t is string => Boolean(t));
+  if (passages.length) return passages.join('\n\n');
+  return r.snippet ?? r.content ?? r.passage ?? undefined;
+}
+
+async function callCaesar(query: string): Promise<CaesarResponse> {
+  const apiKey = process.env.CAESAR_API_KEY;
+  if (!apiKey) {
+    throw new Error('[Caesar API] CAESAR_API_KEY is not set');
+  }
+
+  const response = await fetch(CAESAR_API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ query, max_results: 5 }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`[Caesar API] ${response.status}: ${text}`);
+  }
+
+  return response.json() as Promise<CaesarResponse>;
+}
+
+export const caesarSearch = new DynamicStructuredTool({
+  name: 'web_search',
+  description:
+    'Search the web for current information on any topic. Returns relevant search results with URLs and content snippets.',
+  schema: z.object({
+    query: z.string().describe('The search query to look up on the web'),
+  }),
+  func: async (input) => {
+    try {
+      const res = await callCaesar(input.query);
+
+      const results = res.results ?? [];
+      const urls: string[] = [];
+      const formattedResults = results.map((r) => {
+        const url = r.url ?? r.canonical_url ?? r.source_url;
+        if (url && !urls.includes(url)) {
+          urls.push(url);
+        }
+        const published = r.metadata?.published_at ?? undefined;
+        return {
+          title: r.title,
+          url,
+          snippet: contentFor(r),
+          ...(published ? { published } : {}),
+        };
+      });
+
+      const data = { results: formattedResults };
+      return formatToolResult(data, urls.length ? urls : undefined);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`[Caesar API] error: ${message}`);
+      throw new Error(`[Caesar API] ${message}`);
+    }
+  },
+});

--- a/src/tools/search/index.ts
+++ b/src/tools/search/index.ts
@@ -30,4 +30,5 @@ export { tavilySearch } from './tavily.js';
 export { exaSearch } from './exa.js';
 export { perplexitySearch } from './perplexity.js';
 export { langSearch } from './langsearch.js';
+export { caesarSearch } from './caesar.js';
 export { xSearchTool, X_SEARCH_DESCRIPTION } from './x-search.js';

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -100,13 +100,14 @@ export function saveApiKeyForProvider(providerId: string, apiKey: string): boole
   return saveApiKeyToEnv(apiKeyName, apiKey);
 }
 
-export type SearchProviderId = 'exa' | 'perplexity' | 'tavily' | 'langsearch';
+export type SearchProviderId = 'exa' | 'perplexity' | 'tavily' | 'langsearch' | 'caesar';
 
 export const SEARCH_PROVIDERS: Record<SearchProviderId, { displayName: string; apiKeyEnvVar: string }> = {
   exa: { displayName: 'Exa', apiKeyEnvVar: 'EXASEARCH_API_KEY' },
   perplexity: { displayName: 'Perplexity', apiKeyEnvVar: 'PERPLEXITY_API_KEY' },
   tavily: { displayName: 'Tavily', apiKeyEnvVar: 'TAVILY_API_KEY' },
   langsearch: { displayName: 'LangSearch', apiKeyEnvVar: 'LANGSEARCH_API_KEY' },
+  caesar: { displayName: 'Caesar', apiKeyEnvVar: 'CAESAR_API_KEY' },
 };
 
 export function getSearchProviderDisplayName(providerId: SearchProviderId): string {


### PR DESCRIPTION
Adds [Caesar](https://docs.trycaesar.com) as a fifth `web_search` backend alongside Exa, Perplexity, Tavily, and LangSearch.

What makes it worth a slot: **Caesar returns the passages it selected for your query inline with each search result**, so for most questions the agent does not need a second round trip to read the page. The other four providers return a title, a URL, and a snippet; getting the text that actually answers the question is a follow-up fetch.

### What that looks like

Caesar's `snippet` field is the page's meta description. Its `passages` field is query-conditioned. Same document, two different queries, zero overlap in the passages returned:

```
query: "work stealing balancing load across worker threads"
  -> "That notified processor will steal half the tasks in the batch, and in turn notify another..."

query: "atomic reference counting overhead in the old scheduler"
  -> "There are many outstanding references to the task structure: the scheduler and each waker..."
```

Both from `tokio.rs/blog/2019-10-scheduler`. So the provider surfaces `passages` and falls back to `snippet` when a result has none. That is the same preference LangSearch's provider already makes when it takes `summary` over its own shorter `snippet`, so I followed that rather than inventing a new field.

Concretely, on `why did tokio avoid the atomic increment in wake_by_ref` across 5 results:

| | text handed to the agent | top result answers the question |
|---|---|---|
| meta description | 1,148 chars | no |
| query-selected passages | 4,690 chars | yes |

Each result also carries a publication date, surfaced as `published` when the document has one. For a research agent that reasons over filings and news, knowing a source is from 2019 rather than last week seemed worth keeping.

### Tradeoff, stated plainly

Passages make each response roughly 4x larger than a snippet-only mapping, so a `web_search` call costs more context tokens. I think that is the right trade for this agent, because the alternative is spending a fetch plus the whole page. If you would rather keep responses small, the mapper is one function (`contentFor`) and can prefer `snippet` instead.

### Scope

Additive. The only existing files touched are the ones any new provider touches: the `SearchProviderId` union and `SEARCH_PROVIDERS` in `src/utils/env.ts`, registration in `src/tools/registry.ts` (guarded by `process.env.CAESAR_API_KEY`, exactly like the other four), the `/search` menu entry, the barrel export, and `env.example`. No existing provider is modified and no shared type is widened.

`CAESAR_API_KEY` is required and sent as `Authorization: Bearer <key>`. Missing key throws `[Caesar API] CAESAR_API_KEY is not set`, mirroring `search_langsearch`.

### Tested

```
$ bun test
 81 pass  0 fail

$ tsc --noEmit
(clean)
```

`src/tools/search/caesar.test.ts` covers the Bearer header, the missing-key throw, passage preference, the snippet fallback when a result has no passages, empty-passage handling, alternate url/snippet field names, and a 401.

Beyond the mocked units I ran a real query through the built tool:

```
$ bun -e 'import { caesarSearch } from "./src/tools/search/caesar.ts";
  const r = JSON.parse(await caesarSearch.invoke({ query: "why did tokio avoid the atomic increment in wake_by_ref" }));
  console.log(r.data.results[0]);'

title    : Making the Tokio scheduler 10x faster | Tokio
published : 2019-10-13T00:00:00Z
chars    : 1208
snippet  : "It was observed that when Waker::wake is called, often times the original waker
            reference is no longer needed. This allows for reusing the atomic reference count
            when pushing the task into the run queue..."
```

That is the answer to the question, returned by the search call itself.

---

Disclosure: I work on GTM for Caesar. I wrote this to match how `langsearch.ts` is built rather than as a vendor drop-in, and I am happy to adjust the mapping, the priority placement, or the `published` field to fit your conventions.
