### PR TITLE
Add Requesty as an LLM provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@
 
 ## LLM Providers
 
-- Supported: OpenAI (default), Anthropic, Google, xAI (Grok), OpenRouter, Ollama (local).
+- Supported: OpenAI (default), Anthropic, Google, xAI (Grok), OpenRouter, Requesty, Ollama (local).
 - Default model: `gpt-5.5`. Provider detection is prefix-based (`claude-` -> Anthropic, `gemini-` -> Google, etc.).
 - Fast models for lightweight tasks: see `FAST_MODELS` map in `src/model/llm.ts`.
 - Anthropic uses explicit `cache_control` on system prompt for prompt caching cost savings.
@@ -78,7 +78,7 @@
 
 ## Environment Variables
 
-- LLM keys: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `XAI_API_KEY`, `OPENROUTER_API_KEY`
+- LLM keys: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `XAI_API_KEY`, `OPENROUTER_API_KEY`, `REQUESTY_API_KEY`
 - Ollama: `OLLAMA_BASE_URL` (default `http://127.0.0.1:11434`)
 - Finance: `FINANCIAL_DATASETS_API_KEY`
 - Search: `EXASEARCH_API_KEY` (preferred), `TAVILY_API_KEY` (fallback)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ cp env.example .env
 # GOOGLE_API_KEY=your-google-api-key (optional)
 # XAI_API_KEY=your-xai-api-key (optional)
 # OPENROUTER_API_KEY=your-openrouter-api-key (optional)
+# REQUESTY_API_KEY=your-requesty-api-key (optional)
 
 # Institutional-grade market data for agents
 # FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key

--- a/env.example
+++ b/env.example
@@ -4,6 +4,7 @@ ANTHROPIC_API_KEY=your-anthropic-api-key
 GOOGLE_API_KEY=your-google-api-key
 XAI_API_KEY=your-xai-api-key
 OPENROUTER_API_KEY=your-openrouter-api-key
+REQUESTY_API_KEY=your-requesty-api-key
 MOONSHOT_API_KEY=your-moonshot-api-key
 DEEPSEEK_API_KEY=your-deepseek-api-key
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -671,9 +671,11 @@ export async function runCli() {
       const input = new ApiKeyInputComponent();
       input.onSubmit = (value) => modelSelection.handleModelInputSubmit(value);
       input.onCancel = () => modelSelection.handleModelInputSubmit(null);
+      const modelCatalogUrl =
+        state.pendingProvider === 'requesty' ? 'app.requesty.ai/router/list' : 'openrouter.ai/models';
       showScreenView(
         `Enter model name for ${getProviderDisplayName(state.pendingProvider)}`,
-        'Type or paste the model name from openrouter.ai/models',
+        `Type or paste the model name from ${modelCatalogUrl}`,
         input,
         'Examples: anthropic/claude-3.5-sonnet, openai/gpt-4-turbo, meta-llama/llama-3-70b\nEnter to confirm · esc to go back',
         input,

--- a/src/controllers/model-selection.ts
+++ b/src/controllers/model-selection.ts
@@ -94,7 +94,7 @@ export class ModelSelectionController {
     }
 
     this.pendingProviderValue = providerId;
-    if (providerId === 'openrouter') {
+    if (providerId === 'openrouter' || providerId === 'requesty') {
       this.pendingModelsValue = [];
       this.appStateValue = 'model_input';
       this.emitChange();

--- a/src/model/llm.ts
+++ b/src/model/llm.ts
@@ -96,6 +96,15 @@ const MODEL_FACTORIES: Record<string, ModelFactory> = {
         baseURL: 'https://openrouter.ai/api/v1',
       },
     }),
+  requesty: (name, opts) =>
+    new ChatOpenAI({
+      model: name.replace(/^requesty:/, ''),
+      ...opts,
+      apiKey: getApiKey('REQUESTY_API_KEY'),
+      configuration: {
+        baseURL: 'https://router.requesty.ai/v1',
+      },
+    }),
   moonshot: (name, opts) =>
     new ChatOpenAI({
       model: name,

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -76,6 +76,14 @@ export const PROVIDERS: ProviderDef[] = [
     contextWindow: 128_000,
   },
   {
+    id: 'requesty',
+    displayName: 'Requesty',
+    modelPrefix: 'requesty:',
+    apiKeyEnvVar: 'REQUESTY_API_KEY',
+    fastModel: 'requesty:openai/gpt-4o-mini',
+    contextWindow: 128_000,
+  },
+  {
     id: 'ollama',
     displayName: 'Ollama',
     modelPrefix: 'ollama:',

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -58,7 +58,7 @@ export function getDefaultModelForProvider(providerId: string): string | undefin
 }
 
 export function getModelDisplayName(modelId: string): string {
-  const normalizedId = modelId.replace(/^(ollama|ollama-cloud|openrouter):/, '');
+  const normalizedId = modelId.replace(/^(ollama|ollama-cloud|openrouter|requesty):/, '');
 
   for (const provider of PROVIDERS) {
     const model = provider.models.find((entry) => entry.id === normalizedId || entry.id === modelId);


### PR DESCRIPTION
## What

Adds Requesty ([requesty.ai](https://requesty.ai)) as a first-class LLM provider, mirroring the existing OpenRouter provider.

Requesty is an OpenAI-compatible LLM gateway/router. Because it is OpenAI-compatible and uses the same `provider/model` naming convention as OpenRouter, the wiring is a direct mirror of the OpenRouter path.

## Changes

- `src/providers.ts`: register the `requesty` provider in the canonical `PROVIDERS` registry, `requesty:` model prefix, `REQUESTY_API_KEY` env var, fast model `requesty:openai/gpt-4o-mini`.
- `src/model/llm.ts`: add a `requesty` `ChatOpenAI` factory with `baseURL: https://router.requesty.ai/v1`, strips the `requesty:` prefix from the model name (same pattern as OpenRouter).
- `src/utils/model.ts`: strip the `requesty:` prefix when resolving display names.
- `src/controllers/model-selection.ts`: route `requesty` to the free-form model-name input (same flow as OpenRouter, since models are `provider/model`).
- `src/cli.ts`: point the model-name hint at `app.requesty.ai/router/list` when the provider is Requesty.
- `env.example`, `README.md`, `AGENTS.md`: document `REQUESTY_API_KEY`.

Config details:
- Base URL: `https://router.requesty.ai/v1`
- Auth: `Authorization: Bearer $REQUESTY_API_KEY`
- Model naming: `provider/model` (e.g. `requesty:openai/gpt-4o-mini`, `requesty:anthropic/claude-sonnet-4-5`)

Docs: https://docs.requesty.ai · API keys: https://app.requesty.ai/api-keys · Model list: https://app.requesty.ai/router/list

## Testing

- `bun run typecheck`: passes.
- `bun test`: 292 pass, 0 fail.
- Live-tested through the actual provider code path: called `callLlm('...', { model: 'requesty:openai/gpt-4o-mini' })` against the live `https://router.requesty.ai/v1` endpoint with a real key; the model returned the expected marker `DEXTER_REQUESTY_OK`.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.

