### PR TITLE
feat: add pluggable data sources 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,12 @@ yarn-error.log*
 # Cursor files
 .cursor/
 
+# workbuddy
+.workbuddy/
+
+# Futu bridge runtime logs
+futu-bridge/*.log
+
 # Dexter context files (offloaded tool outputs)
 .dexter/*
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Dexter is an autonomous financial research agent that thinks, plans, and learns 
 - [✅ Prerequisites](#-prerequisites)
 - [💻 How to Install](#-how-to-install)
 - [🚀 How to Run](#-how-to-run)
+- [🔌 Data Sources (Key-Free Alternatives)](#-data-sources-key-free-alternatives)
 - [📊 How to Evaluate](#-how-to-evaluate)
 - [🐛 How to Debug](#-how-to-debug)
 - [📱 How to Use with WhatsApp](#-how-to-use-with-whatsapp)
@@ -49,7 +50,7 @@ Dexter takes complex financial questions and turns them into clear, step-by-step
 
 - [Bun](https://bun.com) runtime (v1.0 or higher)
 - OpenAI API key (get [here](https://platform.openai.com/api-keys))
-- Financial Datasets API key (get [here](https://financialdatasets.ai))
+- Financial Datasets API key (get [here](https://financialdatasets.ai)) — optional; see [Data Sources](#-data-sources-key-free-alternatives) for key-free alternatives
 - Exa API key (get [here](https://exa.ai)) - optional, for web search
 
 #### Installing Bun
@@ -118,6 +119,65 @@ Or with watch mode for development:
 ```bash
 bun dev
 ```
+
+## 🔌 Data Sources (Key-Free Alternatives)
+
+By default Dexter pulls market data from the Financial Datasets API via `FINANCIAL_DATASETS_API_KEY`. The data layer in `src/tools/finance/api.ts` is **pluggable**: each endpoint category is routed to a configurable source, so you can run a fully key-free stack. Unsupported endpoints fall back to Financial Datasets and return a clear error when its key is absent, letting the agent degrade to web research.
+
+| Endpoint category | Source | Activation |
+|---|---|---|
+| Prices & crypto (`/prices`, `/crypto`) | **Futu OpenD** | `FUTU_BRIDGE_URL` |
+| SEC filings (`/filings`) | **SEC EDGAR** | `USE_SEC_EDGAR=true` (no key) |
+| Fundamentals, metrics, earnings, news, institutional holdings | **Financial Modeling Prep** | `FMP_API_KEY` |
+| Insider trades, beneficial ownership, stock screener | Financial Datasets | no free source; 401s gracefully when unset |
+
+### Market data via Futu OpenD
+
+`futu-api` is Python-only, so Dexter talks to a small local bridge (`futu-bridge/server.py`) that proxies FutuOpenD over REST.
+
+1. Create a venv and install the bridge dependency:
+```bash
+python3 -m venv futu-bridge/.venv
+futu-bridge/.venv/bin/pip install futu-api
+```
+
+2. Start the bridge (requires FutuOpenD running on `127.0.0.1:11111`):
+```bash
+futu-bridge/.venv/bin/python futu-bridge/server.py
+```
+
+3. Point Dexter at the bridge in `.env`:
+```bash
+FUTU_BRIDGE_URL=http://127.0.0.1:8765
+```
+
+> **Note:** Crypto codes are resolved as `US.<SYMBOL>` (e.g. `BTC-USD` → `US.BTC`), which maps to a Bitcoin trust ETF on some accounts when spot crypto is not enabled. Update the prefix in `futu-bridge/server.py` if your account exposes true spot symbols.
+
+### SEC filings via SEC EDGAR (no key required)
+
+```bash
+USE_SEC_EDGAR=true
+```
+Routes 10-K / 10-Q / 8-K lookups to the free [SEC EDGAR](https://www.sec.gov/edgar) API.
+
+### Fundamentals via Financial Modeling Prep
+
+Register a free key at [financialmodelingprep.com](https://financialmodelingprep.com) and set:
+```bash
+FMP_API_KEY=your-fmp-api-key
+```
+
+### Running Dexter
+
+With the bridge running and `.env` configured, start Dexter as usual:
+```bash
+bun start
+```
+
+> **Running without Bun:** if your environment's `better-sqlite3` native binding was built against a different Node ABI, run Dexter directly on a matching Node via `tsx`:
+> ```bash
+> env -u NODE_OPTIONS /opt/homebrew/opt/node@20/bin/node node_modules/tsx/dist/cli.mjs src/index.tsx
+> ```
 
 ## 📊 How to Evaluate
 

--- a/env.example
+++ b/env.example
@@ -18,6 +18,23 @@ OLLAMA_CLOUD_API_KEY=your-ollama-cloud-api-key
 # Stock Market API Key
 FINANCIAL_DATASETS_API_KEY=your-financial-datasets-api-key
 
+# ---------------------------------------------------------------------------
+# Free / self-hosted financial data sources (drop-in alternatives)
+# Any of these can replace Financial Datasets for the endpoints they cover.
+# Dexter routes each endpoint category to the first configured alternative.
+# ---------------------------------------------------------------------------
+
+# 1) Futu OpenD bridge — market data (prices / crypto), requires futu-bridge running.
+#    Start it with: futu-bridge/.venv/bin/python futu-bridge/server.py
+FUTU_BRIDGE_URL=http://127.0.0.1:8765
+
+# 2) SEC EDGAR — SEC filings (10-K/10-Q/8-K), free, no key required.
+USE_SEC_EDGAR=true
+
+# 3) Financial Modeling Prep — fundamentals (statements, ratios, earnings, news,
+#    institutional holders). Free tier key from financialmodelingprep.com.
+FMP_API_KEY=your-fmp-api-key
+
 # Web Search API Keys (Exa → Perplexity → Tavily → LangSearch)
 EXASEARCH_API_KEY=your-exa-api-key
 PERPLEXITY_API_KEY=your-perplexity-api-key

--- a/futu-bridge/requirements.txt
+++ b/futu-bridge/requirements.txt
@@ -1,0 +1,1 @@
+futu-api

--- a/futu-bridge/server.py
+++ b/futu-bridge/server.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""
+Futu OpenD -> Dexter bridge.
+
+Exposes a tiny local REST API that mirrors the subset of Financial Datasets
+endpoints Dexter's market-data tools call, backed by FutuOpenD (futu-api).
+
+Endpoints
+  GET /health
+  GET /prices/snapshot?ticker=AAPL           -> {"snapshot": {...}}
+  GET /prices?ticker=AAPL&interval=day&start_date=YYYY-MM-DD&end_date=YYYY-MM-DD -> {"prices": [...]}
+  GET /prices/snapshot/tickers?market=US      -> {"tickers": [{ticker, name}, ...]}
+  GET /crypto/prices/snapshot?ticker=BTC-USD  -> {"snapshot": {...}}
+  GET /crypto/prices?ticker=BTC-USD&interval=day&start_date=..&end_date=.. -> {"prices": [...]}
+  GET /crypto/prices/tickers                  -> {"tickers": [{ticker, name}, ...]}
+
+Run:
+  futu-bridge/.venv/bin/python futu-bridge/server.py
+Env:
+  FUTU_OPEND_HOST (default 127.0.0.1)
+  FUTU_OPEND_PORT (default 11111)
+  FUTU_BRIDGE_HOST (default 127.0.0.1)
+  FUTU_BRIDGE_PORT (default 8765)
+"""
+import json
+import math
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse, parse_qs
+
+import pandas as pd
+
+from futu import (
+    OpenQuoteContext,
+    Market,
+    SecurityType,
+    SubType,
+    RET_OK,
+    KLType,
+)
+
+OPEND_HOST = os.getenv("FUTU_OPEND_HOST", "127.0.0.1")
+OPEND_PORT = int(os.getenv("FUTU_OPEND_PORT", "11111"))
+BRIDGE_HOST = os.getenv("FUTU_BRIDGE_HOST", "127.0.0.1")
+BRIDGE_PORT = int(os.getenv("FUTU_BRIDGE_PORT", "8765"))
+
+# --- helpers ---------------------------------------------------------------
+
+_lock = threading.Lock()
+_ctx = None
+
+
+def get_ctx():
+    global _ctx
+    if _ctx is None:
+        _ctx = OpenQuoteContext(host=OPEND_HOST, port=OPEND_PORT)
+    return _ctx
+
+
+def safe(v):
+    """Make a value JSON-serialisable (no NaN / Timestamp)."""
+    if v is None:
+        return None
+    try:
+        if isinstance(v, float) and (math.isnan(v) or math.isinf(v)):
+            return None
+    except TypeError:
+        pass
+    if hasattr(v, "isoformat"):  # pandas Timestamp / datetime
+        return str(v)
+    if isinstance(v, (list, tuple)):
+        return [safe(x) for x in v]
+    if isinstance(v, dict):
+        return {k: safe(val) for k, val in v.items()}
+    return v
+
+
+def records_from_df(df):
+    if df is None or len(df) == 0:
+        return []
+    return [safe(r) for r in df.to_dict("records")]
+
+
+def to_code(ticker: str, default_market: str = "US") -> str:
+    """Normalise a ticker to a Futu code (e.g. US.AAPL / HK.00700 / CRYPTO.BTCUSD)."""
+    t = (ticker or "").strip().upper()
+    if not t:
+        return t
+    if "." in t:  # already qualified
+        return t
+    if default_market == "CRYPTO":
+        # BTC-USD -> US.BTC ; BTC -> US.BTC
+        base = t.split("-")[0]
+        return f"US.{base}"
+    if default_market == "HK":
+        return f"HK.{t}"
+    if default_market == "SH":
+        return f"SH.{t}"
+    if default_market == "SZ":
+        return f"SZ.{t}"
+    return f"US.{t}"
+
+
+_KTYPE_MAP = {
+    "minute": KLType.K_1M,
+    "1m": KLType.K_1M,
+    "5m": KLType.K_5M,
+    "15m": KLType.K_15M,
+    "30m": KLType.K_30M,
+    "60m": KLType.K_60M,
+    "day": KLType.K_DAY,
+    "week": KLType.K_WEEK,
+    "month": KLType.K_MON,
+    "quarter": KLType.K_QUARTER,
+    "year": KLType.K_YEAR,
+}
+
+
+def ktype(interval: str, multiplier: int = 1):
+    key = (interval or "day").lower()
+    if key == "minute":
+        m = multiplier or 1
+        return {
+            1: KLType.K_1M,
+            5: KLType.K_5M,
+            15: KLType.K_15M,
+            30: KLType.K_30M,
+            60: KLType.K_60M,
+        }.get(m, KLType.K_1M)
+    return _KTYPE_MAP.get(key, KLType.K_DAY)
+
+
+# --- mapping ---------------------------------------------------------------
+
+def map_snapshot(rec: dict) -> dict:
+    last = rec.get("last_price")
+    prev = rec.get("prev_close_price")
+    change = None
+    change_pct = None
+    if last is not None and prev not in (None, 0):
+        change = round(last - prev, 6)
+        change_pct = round(change / prev * 100, 4)
+    return {
+        "ticker": rec.get("code", "").split(".", 1)[-1],
+        "name": rec.get("name"),
+        "price": last,
+        "open": rec.get("open_price"),
+        "high": rec.get("high_price"),
+        "low": rec.get("low_price"),
+        "close": last,
+        "prev_close": prev,
+        "change": change,
+        "change_percent": change_pct,
+        "volume": rec.get("volume"),
+        "turnover": rec.get("turnover"),
+        "timestamp": rec.get("update_time"),
+        "pe_ratio": rec.get("pe_ratio"),
+        "pe_ttm": rec.get("pe_ttm_ratio"),
+        "pb_ratio": rec.get("pb_ratio"),
+        "market_cap": rec.get("total_market_val"),
+        "fifty_two_week_high": rec.get("highest52weeks_price"),
+        "fifty_two_week_low": rec.get("lowest52weeks_price"),
+    }
+
+
+def map_price(rec: dict) -> dict:
+    return {
+        "ticker": rec.get("code", "").split(".", 1)[-1],
+        "date": str(rec.get("time_key"))[:10],
+        "open": rec.get("open"),
+        "high": rec.get("high"),
+        "low": rec.get("low"),
+        "close": rec.get("close"),
+        "volume": rec.get("volume"),
+        "turnover": rec.get("turnover"),
+    }
+
+
+def snapshot_for(ticker: str, market: str) -> dict:
+    code = to_code(ticker, market)
+    with _lock:
+        ret, data = get_ctx().get_market_snapshot([code])
+    if ret != RET_OK:
+        raise RuntimeError(f"Futu snapshot failed for {code}: {data}")
+    recs = records_from_df(data)
+    if not recs:
+        return {"snapshot": {}}
+    return {"snapshot": map_snapshot(recs[0])}
+
+
+def history_for(ticker: str, market: str, interval: str, start: str, end: str, multiplier: int = 1) -> dict:
+    code = to_code(ticker, market)
+    kt = ktype(interval, multiplier)
+    frames = []
+    page_key = None
+    with _lock:
+        while True:
+            ret, data, page_key = get_ctx().request_history_kline(
+                code, start=start, end=end, ktype=kt, max_count=1000, page_req_key=page_key
+            )
+            if ret != RET_OK:
+                raise RuntimeError(f"Futu history failed for {code}: {data}")
+            frames.append(data)
+            if page_key is None or len(data) == 0:
+                break
+    combined = pd.concat(frames) if frames else data
+    recs = [map_price(r) for r in records_from_df(combined)]
+    return {"prices": recs}
+
+
+def ticker_list(market: str) -> dict:
+    m = {
+        "US": Market.US,
+        "HK": Market.HK,
+        "SH": Market.SH,
+        "SZ": Market.SZ,
+    }.get((market or "US").upper(), Market.US)
+    with _lock:
+        ret, data = get_ctx().get_stock_basicinfo(m, SecurityType.STOCK)
+    if ret != RET_OK:
+        raise RuntimeError(f"Futu basicinfo failed for {market}: {data}")
+    out = []
+    for r in records_from_df(data):
+        code = r.get("code", "")
+        out.append({"ticker": code.split(".", 1)[-1], "name": r.get("name"), "market": code.split(".", 1)[0]})
+    return {"tickers": out}
+
+
+def crypto_ticker_list() -> dict:
+    # Futu does not enumerate crypto via basicinfo on all accounts; return a
+    # curated set of the most common US-quoted crypto tickers.
+    curated = [
+        ("BTC-USD", "Bitcoin"),
+        ("ETH-USD", "Ethereum"),
+        ("SOL-USD", "Solana"),
+        ("BNB-USD", "BNB"),
+        ("XRP-USD", "XRP"),
+        ("DOGE-USD", "Dogecoin"),
+        ("ADA-USD", "Cardano"),
+        ("AVAX-USD", "Avalanche"),
+        ("LINK-USD", "Chainlink"),
+        ("MATIC-USD", "Polygon"),
+    ]
+    return {"tickers": [{"ticker": t, "name": n} for t, n in curated]}
+
+
+# --- HTTP handler ----------------------------------------------------------
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):  # quiet
+        pass
+
+    def _send(self, payload, status=200):
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _err(self, msg, status=502):
+        self._send({"error": msg}, status)
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        path = parsed.path
+        q = parse_qs(parsed.query)
+        g = lambda k, d=None: (q.get(k, [d])[0] if k in q else d)
+
+        try:
+            if path == "/health":
+                self._send({"status": "ok", "source": "futu-opend"})
+                return
+
+            if path == "/prices/snapshot":
+                self._send(snapshot_for(g("ticker", ""), "US"))
+                return
+
+            if path == "/prices":
+                self._send(history_for(
+                    g("ticker", ""), "US",
+                    g("interval", "day"),
+                    g("start_date", ""), g("end_date", ""),
+                ))
+                return
+
+            if path == "/prices/snapshot/tickers":
+                self._send(ticker_list(g("market", "US")))
+                return
+
+            if path == "/crypto/prices/snapshot":
+                self._send(snapshot_for(g("ticker", ""), "CRYPTO"))
+                return
+
+            if path == "/crypto/prices":
+                self._send(history_for(
+                    g("ticker", ""), "CRYPTO",
+                    g("interval", "day"),
+                    g("start_date", ""), g("end_date", ""),
+                    int(g("interval_multiplier", 1) or 1),
+                ))
+                return
+
+            if path == "/crypto/prices/tickers":
+                self._send(crypto_ticker_list())
+                return
+
+            self._err(f"unknown endpoint: {path}", status=404)
+        except Exception as e:  # noqa
+            self._err(str(e))
+
+
+def main():
+    server = ThreadingHTTPServer((BRIDGE_HOST, BRIDGE_PORT), Handler)
+    print(f"Futu bridge listening on http://{BRIDGE_HOST}:{BRIDGE_PORT} (OpenD {OPEND_HOST}:{OPEND_PORT})")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/finance/api.test.ts
+++ b/src/tools/finance/api.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect } from 'bun:test';
+import { stripFieldsDeep } from './api.js';
+
+type ApiModule = typeof import('./api.js');
+
+/**
+ * resolveSource() reads its control env vars at module-load time, so each
+ * scenario sets the env and re-imports the module with a cache-busting query
+ * to get a fresh evaluation.
+ */
+function setEnv(overrides: Record<string, string | undefined>) {
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}
+
+async function loadApi(bust: string): Promise<ApiModule> {
+  return import(`./api.js?bust=${bust}`) as Promise<ApiModule>;
+}
+
+const CLEAR = { FUTU_BRIDGE_URL: undefined, FMP_API_KEY: undefined, USE_SEC_EDGAR: undefined };
+
+describe('resolveSource routing', () => {
+  test('falls back to financialdatasets when no alt source is configured', async () => {
+    setEnv(CLEAR);
+    const { resolveSource } = await loadApi('none');
+    expect(resolveSource('/prices/snapshot/')).toBe('financialdatasets');
+    expect(resolveSource('/crypto/prices/')).toBe('financialdatasets');
+    expect(resolveSource('/filings/')).toBe('financialdatasets');
+    expect(resolveSource('/financials/income-statements/')).toBe('financialdatasets');
+    expect(resolveSource('/insider-trades/')).toBe('financialdatasets');
+    expect(resolveSource('/stock-screener/')).toBe('financialdatasets');
+  });
+
+  test('routes market data to futu when FUTU_BRIDGE_URL is set', async () => {
+    setEnv({ ...CLEAR, FUTU_BRIDGE_URL: 'http://127.0.0.1:8765' });
+    const { resolveSource } = await loadApi('futu');
+    expect(resolveSource('/prices/snapshot/')).toBe('futu');
+    expect(resolveSource('/prices/')).toBe('futu');
+    expect(resolveSource('/prices/snapshot/tickers/')).toBe('futu');
+    expect(resolveSource('/crypto/prices/snapshot')).toBe('futu');
+    expect(resolveSource('/crypto/prices/')).toBe('futu');
+    // non-market categories stay on financialdatasets
+    expect(resolveSource('/filings/')).toBe('financialdatasets');
+    expect(resolveSource('/financials/income-statements/')).toBe('financialdatasets');
+  });
+
+  test('routes filings to secedgar when USE_SEC_EDGAR=true', async () => {
+    setEnv({ ...CLEAR, USE_SEC_EDGAR: 'true' });
+    const { resolveSource } = await loadApi('edgar');
+    expect(resolveSource('/filings/')).toBe('secedgar');
+    expect(resolveSource('/filings/items/')).toBe('secedgar');
+    // market data is unaffected by SEC EDGAR
+    expect(resolveSource('/prices/snapshot/')).toBe('financialdatasets');
+  });
+
+  test('routes fundamentals to fmp when FMP_API_KEY is set', async () => {
+    setEnv({ ...CLEAR, FMP_API_KEY: 'dummy' });
+    const { resolveSource } = await loadApi('fmp');
+    expect(resolveSource('/financials/income-statements/')).toBe('fmp');
+    expect(resolveSource('/financial-metrics/')).toBe('fmp');
+    expect(resolveSource('/earnings')).toBe('fmp');
+    expect(resolveSource('/news')).toBe('fmp');
+    expect(resolveSource('/institutional-holdings/')).toBe('fmp');
+    // unrelated endpoints stay on financialdatasets
+    expect(resolveSource('/insider-trades/')).toBe('financialdatasets');
+    expect(resolveSource('/stock-screener/')).toBe('financialdatasets');
+  });
+
+  test('does not misroute /financial-metrics as /financials', async () => {
+    setEnv({ ...CLEAR, FMP_API_KEY: 'dummy' });
+    const { resolveSource } = await loadApi('fmp2');
+    expect(resolveSource('/financial-metrics/')).toBe('fmp');
+    expect(resolveSource('/financials/')).toBe('fmp');
+  });
+});
+
+describe('stripFieldsDeep', () => {
+  test('removes listed top-level fields', () => {
+    const out = stripFieldsDeep({ a: 1, b: 2, c: 3 }, ['b']) as Record<string, unknown>;
+    expect(out).toEqual({ a: 1, c: 3 });
+  });
+
+  test('removes fields nested in objects', () => {
+    const out = stripFieldsDeep({ a: { b: 1, c: 2 }, d: 3 }, ['b']) as Record<string, unknown>;
+    expect(out).toEqual({ a: { c: 2 }, d: 3 });
+  });
+
+  test('removes fields inside arrays of objects', () => {
+    const out = stripFieldsDeep(
+      [
+        { a: 1, secret: 9 },
+        { a: 2, secret: 8 },
+      ],
+      ['secret'],
+    );
+    expect(out).toEqual([{ a: 1 }, { a: 2 }]);
+  });
+
+  test('returns primitives untouched', () => {
+    expect(stripFieldsDeep(42, ['x'])).toBe(42);
+    expect(stripFieldsDeep('s', ['x'])).toBe('s');
+    expect(stripFieldsDeep(null, ['x'])).toBe(null);
+  });
+
+  test('clones structure but strips nothing when field list is empty', () => {
+    const input = { a: { b: 1 }, c: [1, 2] };
+    const out = stripFieldsDeep(input, []) as Record<string, unknown>;
+    expect(out).toEqual(input);
+    expect(out).not.toBe(input);
+  });
+});

--- a/src/tools/finance/api.ts
+++ b/src/tools/finance/api.ts
@@ -3,6 +3,40 @@ import { logger } from '../../utils/logger.js';
 
 const BASE_URL = 'https://api.financialdatasets.ai';
 
+export type Source = 'futu' | 'fmp' | 'secedgar' | 'financialdatasets';
+
+/**
+ * Per-category data-source routing. Each category falls back to the original
+ * Financial Datasets API unless a free alternative is configured:
+ *   - market data (/prices, /crypto)      -> Futu OpenD bridge (FUTU_BRIDGE_URL)
+ *   - SEC filings (/filings)              -> SEC EDGAR (USE_SEC_EDGAR=true)
+ *   - fundamentals (/financials, /financial-metrics, /earnings, /news,
+ *     /institutional-holdings)            -> Financial Modeling Prep (FMP_API_KEY)
+ * Anything not covered stays on Financial Datasets.
+ */
+const FUTU_BRIDGE_URL = (process.env.FUTU_BRIDGE_URL || '').replace(/\/$/, '');
+const FMP_API_KEY = process.env.FMP_API_KEY || '';
+const USE_SEC_EDGAR = (process.env.USE_SEC_EDGAR || '').toLowerCase() === 'true';
+
+export function resolveSource(endpoint: string): Source {
+  if (endpoint.startsWith('/prices') || endpoint.startsWith('/crypto')) {
+    return FUTU_BRIDGE_URL ? 'futu' : 'financialdatasets';
+  }
+  if (endpoint.startsWith('/filings')) {
+    return USE_SEC_EDGAR ? 'secedgar' : 'financialdatasets';
+  }
+  if (
+    endpoint.startsWith('/financials') ||
+    endpoint.startsWith('/financial-metrics') ||
+    endpoint === '/earnings' ||
+    endpoint === '/news' ||
+    endpoint.startsWith('/institutional-holdings')
+  ) {
+    return FMP_API_KEY ? 'fmp' : 'financialdatasets';
+  }
+  return 'financialdatasets';
+}
+
 export interface ApiResponse {
   data: Record<string, unknown>;
   url: string;
@@ -44,9 +78,6 @@ function getApiKey(): string {
   return process.env.FINANCIAL_DATASETS_API_KEY || '';
 }
 
-/**
- * Shared request execution: handles API key, error handling, logging, and response parsing.
- */
 async function executeRequest(
   url: string,
   label: string,
@@ -88,6 +119,26 @@ async function executeRequest(
   return data as Record<string, unknown>;
 }
 
+async function fetchFinancialDatasets(
+  endpoint: string,
+  params: Record<string, string | number | string[] | undefined>,
+): Promise<Record<string, unknown>> {
+  const label = describeRequest(endpoint, params);
+  const url = new URL(`${BASE_URL}${endpoint}`);
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null) {
+      if (Array.isArray(value)) {
+        value.forEach((v) => url.searchParams.append(key, v));
+      } else {
+        url.searchParams.append(key, String(value));
+      }
+    }
+  }
+
+  return executeRequest(url.toString(), label, {});
+}
+
 export const api = {
   async get(
     endpoint: string,
@@ -96,7 +147,6 @@ export const api = {
   ): Promise<ApiResponse> {
     const label = describeRequest(endpoint, params);
 
-    // Check local cache first — avoids redundant network calls for immutable data
     if (options?.cacheable) {
       const cached = readCache(endpoint, params, options.ttlMs);
       if (cached) {
@@ -104,33 +154,40 @@ export const api = {
       }
     }
 
-    const url = new URL(`${BASE_URL}${endpoint}`);
+    const source = resolveSource(endpoint);
+    let data: Record<string, unknown>;
+    let srcUrl: string;
 
-    // Add params to URL, handling arrays
-    for (const [key, value] of Object.entries(params)) {
-      if (value !== undefined && value !== null) {
-        if (Array.isArray(value)) {
-          value.forEach((v) => url.searchParams.append(key, v));
-        } else {
-          url.searchParams.append(key, String(value));
-        }
-      }
+    if (source === 'futu') {
+      const mod = await import('./futu.js');
+      const r = await mod.futuRequest(endpoint, params);
+      data = r.data;
+      srcUrl = r.url;
+    } else if (source === 'fmp') {
+      const mod = await import('./fmp.js');
+      data = await mod.fmpRequest(endpoint, params);
+      srcUrl = `fmp:${endpoint}`;
+    } else if (source === 'secedgar') {
+      const mod = await import('./secedgar.js');
+      data = await mod.secEdgarRequest(endpoint, params);
+      srcUrl = `secedgar:${endpoint}`;
+    } else {
+      data = await fetchFinancialDatasets(endpoint, params);
+      srcUrl = `${BASE_URL}${endpoint}`;
     }
 
-    const data = await executeRequest(url.toString(), label, {});
-
-    // Persist for future requests when the caller marked the response as cacheable
     if (options?.cacheable) {
-      writeCache(endpoint, params, data, url.toString());
+      writeCache(endpoint, params, data, srcUrl);
     }
 
-    return { data, url: url.toString() };
+    return { data, url: srcUrl };
   },
 
   async post(
     endpoint: string,
     body: Record<string, unknown>,
   ): Promise<ApiResponse> {
+    // Screener and other POST endpoints are only offered by Financial Datasets.
     const label = `POST ${endpoint}`;
     const url = `${BASE_URL}${endpoint}`;
 

--- a/src/tools/finance/filings.ts
+++ b/src/tools/finance/filings.ts
@@ -19,11 +19,53 @@ export interface FilingItemTypes {
 let cachedItemTypes: FilingItemTypes | null = null;
 
 /**
+ * Canonical SEC item types, used when filings are served from SEC EDGAR
+ * (USE_SEC_EDGAR=true) so we don't depend on the Financial Datasets API.
+ */
+const SEC_ITEM_TYPES: FilingItemTypes = {
+  '10-K': [
+    { name: 'Item-1', title: 'Business', description: 'Overview of the company’s operations, products, and markets.' },
+    { name: 'Item-1A', title: 'Risk Factors', description: 'Principal risks affecting the business.' },
+    { name: 'Item-1B', title: 'Unresolved Staff Comments', description: 'Comments from SEC staff not yet resolved.' },
+    { name: 'Item-2', title: 'Properties', description: 'Material physical properties owned or leased.' },
+    { name: 'Item-3', title: 'Legal Proceedings', description: 'Significant pending legal proceedings.' },
+    { name: 'Item-4', title: 'Mine Safety Disclosures', description: 'Mine safety disclosures if applicable.' },
+    { name: 'Item-5', title: 'Market for Common Equity', description: 'Market info, dividends, and equity compensation.' },
+    { name: 'Item-7', title: "Management’s Discussion and Analysis", description: 'MD&A of financial condition and results of operations.' },
+    { name: 'Item-7A', title: 'Market Risk Disclosures', description: 'Quantitative/qualitative disclosures about market risk.' },
+    { name: 'Item-8', title: 'Financial Statements', description: 'Consolidated financial statements and supplementary data.' },
+    { name: 'Item-9', title: 'Changes in Accountants', description: 'Changes and disagreements with accountants.' },
+    { name: 'Item-9A', title: 'Controls and Procedures', description: 'Disclosure controls and internal control over financial reporting.' },
+    { name: 'Item-11', title: 'Executive Compensation', description: 'Executive compensation disclosure.' },
+    { name: 'Item-12', title: 'Security Ownership', description: 'Beneficial ownership of securities.' },
+    { name: 'Item-13', title: 'Certain Relationships', description: 'Related-party transactions.' },
+    { name: 'Item-15', title: 'Exhibits', description: 'List of exhibits filed with the report.' },
+  ],
+  '10-Q': [
+    { name: 'Part-1,Item-1', title: 'Financial Statements', description: 'Condensed consolidated financial statements.' },
+    { name: 'Part-1,Item-2', title: "Management’s Discussion and Analysis", description: 'MD&A of financial condition and results of operations.' },
+    { name: 'Part-1,Item-3', title: 'Market Risk Disclosures', description: 'Quantitative/qualitative disclosures about market risk.' },
+    { name: 'Part-2,Item-1', title: 'Legal Proceedings', description: 'Updates to significant legal proceedings.' },
+    { name: 'Part-2,Item-1A', title: 'Risk Factors', description: 'Risk factors (updates to 10-K).' },
+    { name: 'Part-2,Item-3', title: 'Defaults', description: 'Defaults upon senior securities.' },
+    { name: 'Part-2,Item-5', title: 'Other Information', description: 'Other information.' },
+    { name: 'Part-2,Item-6', title: 'Exhibits', description: 'List of exhibits filed with the report.' },
+  ],
+};
+
+/**
  * Fetches canonical item type names from the API.
  * Used to provide the inner LLM with exact item names for selective retrieval.
  */
 export async function getFilingItemTypes(): Promise<FilingItemTypes> {
   if (cachedItemTypes) {
+    return cachedItemTypes;
+  }
+
+  // When serving filings from SEC EDGAR, use the canonical SEC item taxonomy
+  // instead of calling the (keyed) Financial Datasets endpoint.
+  if ((process.env.USE_SEC_EDGAR || '').toLowerCase() === 'true') {
+    cachedItemTypes = SEC_ITEM_TYPES;
     return cachedItemTypes;
   }
 

--- a/src/tools/finance/fmp.ts
+++ b/src/tools/finance/fmp.ts
@@ -1,0 +1,133 @@
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Financial Modeling Prep (FMP) free-tier adapter.
+ *
+ * Activated only when FMP_API_KEY is set. Maps Dexter's fundamentals endpoints
+ * onto FMP's free endpoints and reshapes the JSON into the top-level keys the
+ * finance tools expect (income_statements, balance_sheets, cash_flow_statements,
+ * financial_metrics, snapshot, earnings, news, investors, institutional_holdings).
+ *
+ * NOTE: not all Financial Datasets endpoints have a free FMP equivalent
+ * (insider trades, beneficial ownership, stock screener, segments). Those stay
+ * on Financial Datasets and degrade gracefully without a key.
+ */
+
+const FMP_BASE = 'https://financialmodelingprep.com/api/v3';
+const KEY = process.env.FMP_API_KEY || '';
+
+type Json = unknown;
+
+async function fmpGet(
+  path: string,
+  search: Record<string, string | number | undefined>,
+): Promise<Json> {
+  const url = new URL(`${FMP_BASE}${path}`);
+  url.searchParams.set('apikey', KEY);
+  for (const [k, v] of Object.entries(search)) {
+    if (v !== undefined && v !== null) url.searchParams.set(k, String(v));
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url.toString());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`[FMP] network error: ${message}`);
+  }
+  if (!response.ok) {
+    throw new Error(`[FMP] ${response.status} ${response.statusText}`);
+  }
+  const json = (await response.json()) as Json;
+  if (json && typeof json === 'object' && 'Error Message' in (json as Record<string, unknown>)) {
+    const msg = (json as Record<string, unknown>)['Error Message'];
+    throw new Error(`[FMP] ${String(msg)}`);
+  }
+  return json;
+}
+
+function periodParam(p: unknown): string {
+  const s = String(p || '').toLowerCase();
+  if (s === 'quarterly' || s === 'quarter') return 'quarter';
+  return 'annual';
+}
+
+function tickerOf(params: Record<string, string | number | string[] | undefined>): string {
+  return String(params.ticker || '').toUpperCase();
+}
+
+function limitOf(params: Record<string, string | number | string[] | undefined>, fallback: number): number {
+  const v = params.limit;
+  const n = typeof v === 'number' ? v : Number(v);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+export async function fmpRequest(
+  endpoint: string,
+  params: Record<string, string | number | string[] | undefined>,
+): Promise<Record<string, unknown>> {
+  const ticker = tickerOf(params);
+  const period = periodParam(params.period);
+  const limit = limitOf(params, 5);
+
+  try {
+    switch (endpoint) {
+      case '/financials/income-statements/':
+        return {
+          income_statements: (await fmpGet(`/income-statement/${ticker}`, { period, limit })) as Json,
+        };
+
+      case '/financials/balance-sheets/':
+        return {
+          balance_sheets: (await fmpGet(`/balance-sheet-statement/${ticker}`, { period, limit })) as Json,
+        };
+
+      case '/financials/cash-flow-statements/':
+        return {
+          cash_flow_statements: (await fmpGet(`/cash-flow-statement/${ticker}`, { period, limit })) as Json,
+        };
+
+      case '/financials/':
+        // Best-effort: no single combined endpoint on free FMP; return income
+        // statements under the expected `financials` key.
+        return {
+          financials: (await fmpGet(`/income-statement/${ticker}`, { period, limit })) as Json,
+        };
+
+      case '/financial-metrics/snapshot/': {
+        const ratios = (await fmpGet(`/ratios/${ticker}`, { period, limit: 1 })) as unknown[];
+        return { snapshot: (Array.isArray(ratios) ? ratios[0] : {}) || {} };
+      }
+
+      case '/financial-metrics/':
+        return {
+          financial_metrics: (await fmpGet(`/ratios/${ticker}`, { period, limit })) as Json,
+        };
+
+      case '/earnings':
+        return { earnings: (await fmpGet(`/earnings/${ticker}`, {})) as Json };
+
+      case '/news':
+        return {
+          news: (await fmpGet('/stock_news', { tickers: ticker, limit: limitOf(params, 20) })) as Json,
+        };
+
+      case '/institutional-holdings/investors':
+        return {
+          investors: (await fmpGet(`/institutional-holder/${ticker}`, {})) as Json,
+        };
+
+      case '/institutional-holdings/':
+        return {
+          institutional_holdings: (await fmpGet(`/institutional-holder/${ticker}`, {})) as Json,
+        };
+
+      default:
+        throw new Error(`[FMP] unsupported endpoint: ${endpoint}`);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error(`[FMP] ${message}`);
+    throw new Error(`[FMP] ${message}`);
+  }
+}

--- a/src/tools/finance/futu.ts
+++ b/src/tools/finance/futu.ts
@@ -1,0 +1,77 @@
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Futu OpenD bridge client.
+ *
+ * The Futu OpenD gateway (futu-api, Python-only) is exposed locally by
+ * futu-bridge/server.py as a REST API. This client maps Dexter's market-data
+ * endpoints onto that bridge and returns the JSON unchanged (the bridge
+ * already shapes it as {snapshot} / {prices} / {tickers}).
+ */
+
+const BRIDGE = (process.env.FUTU_BRIDGE_URL || 'http://127.0.0.1:8765').replace(/\/$/, '');
+
+function bridgePath(
+  endpoint: string,
+  params: Record<string, string | number | string[] | undefined>,
+): string {
+  const q = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v === undefined || v === null) continue;
+    if (Array.isArray(v)) v.forEach((x) => q.append(k, String(x)));
+    else q.append(k, String(v));
+  }
+  const query = q.toString();
+
+  switch (endpoint) {
+    case '/prices/snapshot/':
+      return `/prices/snapshot?${query}`;
+    case '/prices/':
+      return `/prices?${query}`;
+    case '/prices/snapshot/tickers/':
+      return `/prices/snapshot/tickers?${query}`;
+    case '/crypto/prices/snapshot/':
+      return `/crypto/prices/snapshot?${query}`;
+    case '/crypto/prices/':
+      return `/crypto/prices?${query}`;
+    case '/crypto/prices/tickers/':
+      return `/crypto/prices/tickers?${query}`;
+    default:
+      throw new Error(`[Futu bridge] unsupported endpoint: ${endpoint}`);
+  }
+}
+
+export interface FutuResponse {
+  data: Record<string, unknown>;
+  url: string;
+}
+
+export async function futuRequest(
+  endpoint: string,
+  params: Record<string, string | number | string[] | undefined>,
+): Promise<FutuResponse> {
+  const path = bridgePath(endpoint, params);
+  const url = `${BRIDGE}${path}`;
+  const label = `${endpoint} ${JSON.stringify(params)}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`[Futu bridge] cannot reach ${BRIDGE} (${label}): ${message}`);
+  }
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`[Futu bridge] ${response.status} ${response.statusText} — ${text}`);
+  }
+
+  const json = (await response.json()) as Record<string, unknown>;
+  if (json && typeof json.error === 'string') {
+    logger.error(`[Futu bridge] upstream error: ${json.error}`);
+    throw new Error(`[Futu bridge] ${json.error}`);
+  }
+
+  return { data: json, url };
+}

--- a/src/tools/finance/secedgar.ts
+++ b/src/tools/finance/secedgar.ts
@@ -1,0 +1,207 @@
+import { logger } from '../../utils/logger.js';
+
+/**
+ * SEC EDGAR adapter (free, no API key required).
+ *
+ * Replaces Financial Datasets for SEC filing access:
+ *   - /filings/         -> lists recent filings via the SEC submissions API
+ *   - /filings/items/   -> fetches the filing's primary document and returns
+ *                          best-effort plain-text content
+ *
+ * Requires a User-Agent per SEC policy.
+ */
+
+const SEC_HEADERS = {
+  'User-Agent': 'dexter/1.0 (local research agent; mailto:dexter@example.com)',
+};
+
+let tickerCikCache: Record<string, number> | null = null;
+let tickerCikPromise: Promise<Record<string, number>> | null = null;
+
+async function loadTickerCikMap(): Promise<Record<string, number>> {
+  if (tickerCikCache) return tickerCikCache;
+  if (tickerCikPromise) return tickerCikPromise;
+  tickerCikPromise = (async () => {
+    const res = await fetch('https://www.sec.gov/files/company_tickers.json', {
+      headers: SEC_HEADERS,
+    });
+    if (!res.ok) throw new Error(`SEC company_tickers.json ${res.status}`);
+    const json = (await res.json()) as Record<string, { ticker: string; cik_str: string }>;
+    const map: Record<string, number> = {};
+    for (const v of Object.values(json)) {
+      map[v.ticker.toUpperCase()] = parseInt(v.cik_str, 10);
+    }
+    tickerCikCache = map;
+    return map;
+  })();
+  return tickerCikPromise;
+}
+
+async function cikForTicker(ticker: string): Promise<number> {
+  const map = await loadTickerCikMap();
+  const cik = map[ticker.toUpperCase()];
+  if (!cik) throw new Error(`SEC EDGAR: unknown ticker ${ticker}`);
+  return cik;
+}
+
+interface Submission {
+  cik: number;
+  filings: {
+    recent: Array<{
+      form: string;
+      filingDate: string;
+      accessionNumber: string;
+      primaryDocument: string;
+      primaryDocDescription?: string;
+      items?: string;
+    }>;
+  };
+}
+
+async function getSubmissions(cik: number): Promise<Submission> {
+  const padded = String(cik).padStart(10, '0');
+  const url = `https://data.sec.gov/submissions/CIK${padded}.json`;
+  const res = await fetch(url, { headers: SEC_HEADERS });
+  if (!res.ok) throw new Error(`SEC submissions ${res.status} for CIK ${padded}`);
+  return (await res.json()) as Submission;
+}
+
+type FilingRow = {
+  form: string;
+  filingDate: string;
+  accessionNumber: string;
+  primaryDocument: string;
+  primaryDocDescription?: string;
+  items?: string;
+};
+
+/**
+ * SEC returns `filings.recent` either as an array of objects (legacy) or as a
+ * column-oriented dict of parallel arrays (current). Normalise to rows.
+ */
+function recentRows(sub: Submission): FilingRow[] {
+  const recent = sub.filings.recent as unknown;
+  if (Array.isArray(recent)) {
+    return recent as FilingRow[];
+  }
+  if (recent && typeof recent === 'object') {
+    const r = recent as Record<string, string[]>;
+    const n = (r.form || []).length;
+    const rows: FilingRow[] = [];
+    for (let i = 0; i < n; i++) {
+      rows.push({
+        form: r.form?.[i],
+        filingDate: r.filingDate?.[i],
+        accessionNumber: r.accessionNumber?.[i],
+        primaryDocument: r.primaryDocument?.[i],
+        primaryDocDescription: r.primaryDocDescription?.[i],
+        items: r.items?.[i],
+      });
+    }
+    return rows;
+  }
+  return [];
+}
+
+function stripHtml(html: string): string {
+  let text = html.replace(/<script[\s\S]*?<\/script>/gi, ' ');
+  text = text.replace(/<style[\s\S]*?<\/style>/gi, ' ');
+  text = text.replace(/<[^>]+>/g, ' ');
+  text = text.replace(/&nbsp;/gi, ' ');
+  text = text.replace(/&amp;/gi, '&');
+  text = text.replace(/&lt;/gi, '<');
+  text = text.replace(/&gt;/gi, '>');
+  text = text.replace(/[ \t]+/g, ' ');
+  text = text.replace(/\n\s*\n+/g, '\n');
+  return text.trim();
+}
+
+async function listFilings(
+  params: Record<string, string | number | string[] | undefined>,
+): Promise<Record<string, unknown>> {
+  const ticker = String(params.ticker || '').toUpperCase();
+  const limit = typeof params.limit === 'number' ? params.limit : Number(params.limit) || 10;
+  const types = Array.isArray(params.filing_type)
+    ? (params.filing_type as string[])
+    : params.filing_type
+      ? [String(params.filing_type)]
+      : [];
+
+  const cik = await cikForTicker(ticker);
+  const sub = await getSubmissions(cik);
+  let rows = recentRows(sub);
+  if (types.length > 0) {
+    rows = rows.filter((r) => types.includes(r.form));
+  }
+  rows = rows.slice(0, limit);
+
+  const filings = rows.map((r) => {
+    const accessionNoDots = r.accessionNumber.replace(/-/g, '');
+    return {
+      ticker,
+      filing_type: r.form,
+      filing_date: r.filingDate,
+      accession_number: r.accessionNumber,
+      primary_document: r.primaryDocument,
+      description: r.primaryDocDescription || '',
+      document_url: `https://www.sec.gov/Archives/edgar/data/${cik}/${accessionNoDots}/${r.primaryDocument}`,
+    };
+  });
+
+  return { filings };
+}
+
+async function getFilingItems(
+  params: Record<string, string | number | string[] | undefined>,
+): Promise<Record<string, unknown>> {
+  const ticker = String(params.ticker || '').toUpperCase();
+  const accessionNumber = String(params.accession_number || '');
+  if (!accessionNumber) throw new Error('SEC EDGAR: accession_number is required');
+
+  const cik = await cikForTicker(ticker);
+  const sub = await getSubmissions(cik);
+  const row = recentRows(sub).find((r) => r.accessionNumber === accessionNumber);
+  if (!row) throw new Error(`SEC EDGAR: accession ${accessionNumber} not found for ${ticker}`);
+
+  const accessionNoDots = accessionNumber.replace(/-/g, '');
+  const docUrl = `https://www.sec.gov/Archives/edgar/data/${cik}/${accessionNoDots}/${row.primaryDocument}`;
+
+  const res = await fetch(docUrl, { headers: SEC_HEADERS });
+  if (!res.ok) throw new Error(`SEC document fetch ${res.status} for ${docUrl}`);
+  const raw = await res.text();
+  const content = stripHtml(raw);
+
+  const items = params.item
+    ? Array.isArray(params.item)
+      ? (params.item as string[])
+      : [String(params.item)]
+    : [];
+
+  return {
+    filing_type: row.form,
+    accession_number: accessionNumber,
+    items_requested: items,
+    content,
+    note: 'Best-effort plain-text extraction of the full filing document. Item-level sectioning is not performed; the model should locate the requested sections within the text.',
+    document_url: docUrl,
+  };
+}
+
+export async function secEdgarRequest(
+  endpoint: string,
+  params: Record<string, string | number | string[] | undefined>,
+): Promise<Record<string, unknown>> {
+  try {
+    if (endpoint === '/filings/' || endpoint.startsWith('/filings?')) {
+      return await listFilings(params);
+    }
+    if (endpoint.startsWith('/filings/items')) {
+      return await getFilingItems(params);
+    }
+    throw new Error(`[SEC EDGAR] unsupported endpoint: ${endpoint}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error(`[SEC EDGAR] ${message}`);
+    throw new Error(`[SEC EDGAR] ${message}`);
+  }
+}


### PR DESCRIPTION
Add pluggable data sources: Futu OpenD, SEC EDGAR, FMP。

Route financial endpoints by category so Dexter can run key-free as an alternative to the paid Financial Datasets API:
1. prices/crypto -> Futu OpenD via a local Python bridge (futu-bridge/server.py)
2. filings -> SEC EDGAR (no key required)
3. fundamentals/metrics/earnings/news/institutional holdings -> FMP (free key)

