### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/env.example
+++ b/env.example
@@ -7,7 +7,11 @@ OPENROUTER_API_KEY=your-openrouter-api-key
 MOONSHOT_API_KEY=your-moonshot-api-key
 DEEPSEEK_API_KEY=your-deepseek-api-key
 MINIMAX_API_KEY=your-minimax-api-key
+# OpenAI-compatible CN endpoint:
 # MINIMAX_BASE_URL=https://api.minimaxi.com/v1
+# Anthropic-compatible CN endpoint:
+# MINIMAX_API_FORMAT=anthropic
+# MINIMAX_BASE_URL=https://api.minimaxi.com/anthropic
 
 # Ollama (Local LLM & Cloud)
 OLLAMA_BASE_URL=http://127.0.0.1:11434

--- a/env.example
+++ b/env.example
@@ -6,6 +6,8 @@ XAI_API_KEY=your-xai-api-key
 OPENROUTER_API_KEY=your-openrouter-api-key
 MOONSHOT_API_KEY=your-moonshot-api-key
 DEEPSEEK_API_KEY=your-deepseek-api-key
+MINIMAX_API_KEY=your-minimax-api-key
+# MINIMAX_BASE_URL=https://api.minimaxi.com/v1
 
 # Ollama (Local LLM & Cloud)
 OLLAMA_BASE_URL=http://127.0.0.1:11434

--- a/src/model/llm.test.ts
+++ b/src/model/llm.test.ts
@@ -20,3 +20,35 @@ describe('OpenAI API routing', () => {
     }
   });
 });
+
+describe('MiniMax API routing', () => {
+  test('uses the configured OpenAI-compatible endpoint', () => {
+    const previousApiKey = process.env.MINIMAX_API_KEY;
+    const previousBaseUrl = process.env.MINIMAX_BASE_URL;
+    process.env.MINIMAX_API_KEY = 'test-key';
+    process.env.MINIMAX_BASE_URL = 'https://api.minimaxi.com/v1';
+
+    try {
+      const llm = getChatModel('minimax:MiniMax-M3') as {
+        clientConfig?: { baseURL?: string };
+        model?: string;
+        modelName?: string;
+      };
+
+      expect(llm.clientConfig?.baseURL).toBe('https://api.minimaxi.com/v1');
+      expect(llm.model ?? llm.modelName).toBe('MiniMax-M3');
+    } finally {
+      if (previousApiKey === undefined) {
+        delete process.env.MINIMAX_API_KEY;
+      } else {
+        process.env.MINIMAX_API_KEY = previousApiKey;
+      }
+
+      if (previousBaseUrl === undefined) {
+        delete process.env.MINIMAX_BASE_URL;
+      } else {
+        process.env.MINIMAX_BASE_URL = previousBaseUrl;
+      }
+    }
+  });
+});

--- a/src/model/llm.test.ts
+++ b/src/model/llm.test.ts
@@ -22,26 +22,62 @@ describe('OpenAI API routing', () => {
 });
 
 describe('MiniMax API routing', () => {
-  test('uses the configured OpenAI-compatible endpoint', () => {
+  test('supports configured OpenAI-compatible and Anthropic-compatible endpoints', () => {
     const previousApiKey = process.env.MINIMAX_API_KEY;
+    const previousApiFormat = process.env.MINIMAX_API_FORMAT;
     const previousBaseUrl = process.env.MINIMAX_BASE_URL;
     process.env.MINIMAX_API_KEY = 'test-key';
-    process.env.MINIMAX_BASE_URL = 'https://api.minimaxi.com/v1';
+    delete process.env.MINIMAX_API_FORMAT;
+    delete process.env.MINIMAX_BASE_URL;
 
     try {
-      const llm = getChatModel('minimax:MiniMax-M3') as {
+      const globalOpenAiLlm = getChatModel('minimax:MiniMax-M3') as {
         clientConfig?: { baseURL?: string };
         model?: string;
         modelName?: string;
       };
 
-      expect(llm.clientConfig?.baseURL).toBe('https://api.minimaxi.com/v1');
-      expect(llm.model ?? llm.modelName).toBe('MiniMax-M3');
+      expect(globalOpenAiLlm.clientConfig?.baseURL).toBe('https://api.minimax.io/v1');
+      expect(globalOpenAiLlm.model ?? globalOpenAiLlm.modelName).toBe('MiniMax-M3');
+
+      process.env.MINIMAX_BASE_URL = 'https://api.minimaxi.com/v1';
+
+      const cnOpenAiLlm = getChatModel('minimax:MiniMax-M2.7') as {
+        clientConfig?: { baseURL?: string };
+      };
+
+      expect(cnOpenAiLlm.clientConfig?.baseURL).toBe('https://api.minimaxi.com/v1');
+
+      process.env.MINIMAX_API_FORMAT = 'anthropic';
+      delete process.env.MINIMAX_BASE_URL;
+
+      const globalAnthropicLlm = getChatModel('minimax:MiniMax-M3') as {
+        apiUrl?: string;
+      };
+
+      expect(globalAnthropicLlm.apiUrl).toBe('https://api.minimax.io/anthropic');
+
+      process.env.MINIMAX_BASE_URL = 'https://api.minimaxi.com/anthropic';
+
+      const cnAnthropicLlm = getChatModel('minimax:MiniMax-M2.7') as {
+        apiUrl?: string;
+        model?: string;
+        modelName?: string;
+      };
+
+      expect(cnAnthropicLlm.apiUrl).toBe('https://api.minimaxi.com/anthropic');
+      expect(cnAnthropicLlm.model ?? cnAnthropicLlm.modelName).toBe('MiniMax-M2.7');
     } finally {
       if (previousApiKey === undefined) {
         delete process.env.MINIMAX_API_KEY;
       } else {
         process.env.MINIMAX_API_KEY = previousApiKey;
+      }
+
+      if (previousApiFormat === undefined) {
+        delete process.env.MINIMAX_API_FORMAT;
+      } else {
+        process.env.MINIMAX_API_FORMAT = previousApiFormat;
       }
 
       if (previousBaseUrl === undefined) {

--- a/src/model/llm.ts
+++ b/src/model/llm.ts
@@ -64,6 +64,16 @@ function getApiKey(envVar: string): string {
   return apiKey;
 }
 
+function getMiniMaxOpenAIBaseUrl(): string {
+  const provider = getProviderById('minimax');
+  return (
+    process.env.MINIMAX_BASE_URL ??
+    provider?.openAIBaseUrl ??
+    provider?.regionalEndpoints?.find((endpoint) => endpoint.region === 'global_en')?.openAIBaseUrl ??
+    'https://api.minimax.io/v1'
+  );
+}
+
 // Factories keyed by provider id — prefix routing is handled by resolveProvider()
 const MODEL_FACTORIES: Record<string, ModelFactory> = {
   anthropic: (name, opts) =>
@@ -126,6 +136,15 @@ const MODEL_FACTORIES: Record<string, ModelFactory> = {
       }),
     });
   },
+  minimax: (name, opts) =>
+    new ChatOpenAI({
+      model: name.replace(/^minimax:/, ''),
+      ...opts,
+      apiKey: getApiKey('MINIMAX_API_KEY'),
+      configuration: {
+        baseURL: getMiniMaxOpenAIBaseUrl(),
+      },
+    }),
   ollama: (name, opts) =>
     new ChatOllama({
       model: name.replace(/^ollama:/, ''),

--- a/src/model/llm.ts
+++ b/src/model/llm.ts
@@ -55,6 +55,7 @@ interface ModelOpts {
 }
 
 type ModelFactory = (name: string, opts: ModelOpts) => BaseChatModel;
+type MiniMaxApiFormat = 'openai' | 'anthropic';
 
 function getApiKey(envVar: string): string {
   const apiKey = process.env[envVar];
@@ -64,12 +65,33 @@ function getApiKey(envVar: string): string {
   return apiKey;
 }
 
-function getMiniMaxOpenAIBaseUrl(): string {
+function getMiniMaxApiFormat(): MiniMaxApiFormat {
+  const format = process.env.MINIMAX_API_FORMAT ?? 'openai';
+  if (format !== 'openai' && format !== 'anthropic') {
+    throw new Error('[LLM] MINIMAX_API_FORMAT must be either openai or anthropic');
+  }
+  return format;
+}
+
+function getMiniMaxBaseUrl(format: MiniMaxApiFormat): string {
   const provider = getProviderById('minimax');
+  const globalEndpoint = provider?.regionalEndpoints?.find(
+    (endpoint) => endpoint.region === 'global_en'
+  );
+
+  if (format === 'anthropic') {
+    return (
+      process.env.MINIMAX_BASE_URL ??
+      provider?.anthropicBaseUrl ??
+      globalEndpoint?.anthropicBaseUrl ??
+      'https://api.minimax.io/anthropic'
+    );
+  }
+
   return (
     process.env.MINIMAX_BASE_URL ??
     provider?.openAIBaseUrl ??
-    provider?.regionalEndpoints?.find((endpoint) => endpoint.region === 'global_en')?.openAIBaseUrl ??
+    globalEndpoint?.openAIBaseUrl ??
     'https://api.minimax.io/v1'
   );
 }
@@ -136,15 +158,30 @@ const MODEL_FACTORIES: Record<string, ModelFactory> = {
       }),
     });
   },
-  minimax: (name, opts) =>
-    new ChatOpenAI({
-      model: name.replace(/^minimax:/, ''),
+  minimax: (name, opts) => {
+    const model = name.replace(/^minimax:/, '');
+    const apiKey = getApiKey('MINIMAX_API_KEY');
+    const format = getMiniMaxApiFormat();
+    const baseUrl = getMiniMaxBaseUrl(format);
+
+    if (format === 'anthropic') {
+      return new ChatAnthropic({
+        model,
+        ...opts,
+        apiKey,
+        anthropicApiUrl: baseUrl,
+      });
+    }
+
+    return new ChatOpenAI({
+      model,
       ...opts,
-      apiKey: getApiKey('MINIMAX_API_KEY'),
+      apiKey,
       configuration: {
-        baseURL: getMiniMaxOpenAIBaseUrl(),
+        baseURL: baseUrl,
       },
-    }),
+    });
+  },
   ollama: (name, opts) =>
     new ChatOllama({
       model: name.replace(/^ollama:/, ''),

--- a/src/providers.test.ts
+++ b/src/providers.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test';
+import { getProviderById, resolveProvider } from './providers.js';
+
+describe('MiniMax provider registration', () => {
+  test('registers OpenAI-compatible and Anthropic-compatible regional endpoints', () => {
+    const provider = getProviderById('minimax');
+
+    expect(provider?.displayName).toBe('MiniMax');
+    expect(provider?.modelPrefix).toBe('minimax:');
+    expect(provider?.apiKeyEnvVar).toBe('MINIMAX_API_KEY');
+    expect(provider?.contextWindow).toBe(1_000_000);
+    expect(provider?.openAIBaseUrl).toBe('https://api.minimax.io/v1');
+    expect(provider?.anthropicBaseUrl).toBe('https://api.minimax.io/anthropic');
+    expect(provider?.regionalEndpoints).toEqual([
+      {
+        region: 'global_en',
+        openAIBaseUrl: 'https://api.minimax.io/v1',
+        anthropicBaseUrl: 'https://api.minimax.io/anthropic',
+        docsRoot: 'https://platform.minimax.io/docs',
+      },
+      {
+        region: 'cn_zh',
+        openAIBaseUrl: 'https://api.minimaxi.com/v1',
+        anthropicBaseUrl: 'https://api.minimaxi.com/anthropic',
+        docsRoot: 'https://platform.minimaxi.com/docs',
+      },
+    ]);
+  });
+
+  test('routes MiniMax-prefixed models to the MiniMax provider', () => {
+    expect(resolveProvider('minimax:MiniMax-M3').id).toBe('minimax');
+    expect(resolveProvider('minimax:MiniMax-M2.7').id).toBe('minimax');
+  });
+
+  test('keeps current MiniMax model metadata in the canonical registry', () => {
+    const models = getProviderById('minimax')?.models ?? [];
+
+    expect(models.map((model) => model.id)).toEqual([
+      'minimax:MiniMax-M3',
+      'minimax:MiniMax-M2.7',
+    ]);
+    expect(models[0]).toMatchObject({
+      contextWindow: 1_000_000,
+      pricingUsdPerMillionTokens: {
+        input: 0.6,
+        output: 2.4,
+        cacheRead: 0.12,
+        cacheWrite: null,
+      },
+      inputModalities: ['text', 'image', 'video'],
+      thinking: ['adaptive', 'disabled'],
+    });
+    expect(models[1]).toMatchObject({
+      contextWindow: 204_800,
+      pricingUsdPerMillionTokens: {
+        input: 0.3,
+        output: 1.2,
+        cacheRead: 0.06,
+        cacheWrite: 0.375,
+      },
+      inputModalities: ['text'],
+      thinking: ['always_on'],
+    });
+  });
+});

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -16,6 +16,35 @@ export interface ProviderDef {
   fastModel?: string;
   /** Default context window size in tokens. Used for model-aware compaction thresholds. */
   contextWindow?: number;
+  /** Default OpenAI-compatible base URL for hosted providers. */
+  openAIBaseUrl?: string;
+  /** Default Anthropic-compatible base URL for hosted providers. */
+  anthropicBaseUrl?: string;
+  /** Region-specific hosted API endpoints. */
+  regionalEndpoints?: ProviderRegionalEndpoint[];
+  /** Provider-owned model metadata used by the model selector. */
+  models?: ProviderModelDef[];
+}
+
+export interface ProviderRegionalEndpoint {
+  region: 'global_en' | 'cn_zh';
+  openAIBaseUrl: string;
+  anthropicBaseUrl?: string;
+  docsRoot: string;
+}
+
+export interface ProviderModelDef {
+  id: string;
+  displayName: string;
+  contextWindow: number;
+  pricingUsdPerMillionTokens?: {
+    input: number;
+    output: number;
+    cacheRead?: number;
+    cacheWrite?: number | null;
+  };
+  inputModalities?: string[];
+  thinking?: string[];
 }
 
 export const PROVIDERS: ProviderDef[] = [
@@ -66,6 +95,58 @@ export const PROVIDERS: ProviderDef[] = [
     apiKeyEnvVar: 'DEEPSEEK_API_KEY',
     fastModel: 'deepseek-v4-flash',
     contextWindow: 1_000_000,
+  },
+  {
+    id: 'minimax',
+    displayName: 'MiniMax',
+    modelPrefix: 'minimax:',
+    apiKeyEnvVar: 'MINIMAX_API_KEY',
+    fastModel: 'minimax:MiniMax-M2.7',
+    contextWindow: 1_000_000,
+    openAIBaseUrl: 'https://api.minimax.io/v1',
+    anthropicBaseUrl: 'https://api.minimax.io/anthropic',
+    regionalEndpoints: [
+      {
+        region: 'global_en',
+        openAIBaseUrl: 'https://api.minimax.io/v1',
+        anthropicBaseUrl: 'https://api.minimax.io/anthropic',
+        docsRoot: 'https://platform.minimax.io/docs',
+      },
+      {
+        region: 'cn_zh',
+        openAIBaseUrl: 'https://api.minimaxi.com/v1',
+        anthropicBaseUrl: 'https://api.minimaxi.com/anthropic',
+        docsRoot: 'https://platform.minimaxi.com/docs',
+      },
+    ],
+    models: [
+      {
+        id: 'minimax:MiniMax-M3',
+        displayName: 'MiniMax M3',
+        contextWindow: 1_000_000,
+        pricingUsdPerMillionTokens: {
+          input: 0.6,
+          output: 2.4,
+          cacheRead: 0.12,
+          cacheWrite: null,
+        },
+        inputModalities: ['text', 'image', 'video'],
+        thinking: ['adaptive', 'disabled'],
+      },
+      {
+        id: 'minimax:MiniMax-M2.7',
+        displayName: 'MiniMax M2.7',
+        contextWindow: 204_800,
+        pricingUsdPerMillionTokens: {
+          input: 0.3,
+          output: 1.2,
+          cacheRead: 0.06,
+          cacheWrite: 0.375,
+        },
+        inputModalities: ['text'],
+        thinking: ['always_on'],
+      },
+    ],
   },
   {
     id: 'openrouter',

--- a/src/utils/model.test.ts
+++ b/src/utils/model.test.ts
@@ -43,3 +43,22 @@ describe('Anthropic model catalog', () => {
     expect(getModelDisplayName('claude-fable-5')).toBe('Fable 5');
   });
 });
+
+describe('MiniMax model catalog', () => {
+  test('offers MiniMax M3 and M2.7 with M3 as the default', () => {
+    expect(getModelIdsForProvider('minimax')).toEqual([
+      'minimax:MiniMax-M3',
+      'minimax:MiniMax-M2.7',
+    ]);
+    expect(getDefaultModelForProvider('minimax')).toBe('minimax:MiniMax-M3');
+  });
+
+  test('uses MiniMax M2.7 for lightweight calls', () => {
+    expect(getProviderById('minimax')?.fastModel).toBe('minimax:MiniMax-M2.7');
+  });
+
+  test('shows the MiniMax model names in the UI', () => {
+    expect(getModelDisplayName('minimax:MiniMax-M3')).toBe('MiniMax M3');
+    expect(getModelDisplayName('minimax:MiniMax-M2.7')).toBe('MiniMax M2.7');
+  });
+});

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -40,7 +40,13 @@ const PROVIDER_MODELS: Record<string, Model[]> = {
 export const PROVIDERS: Provider[] = PROVIDER_DEFS.map((provider) => ({
   displayName: provider.displayName,
   providerId: provider.id,
-  models: PROVIDER_MODELS[provider.id] ?? [],
+  models:
+    PROVIDER_MODELS[provider.id] ??
+    provider.models?.map((model) => ({
+      id: model.id,
+      displayName: model.displayName,
+    })) ??
+    [],
 }));
 
 export function getModelsForProvider(providerId: string): Model[] {
@@ -58,7 +64,7 @@ export function getDefaultModelForProvider(providerId: string): string | undefin
 }
 
 export function getModelDisplayName(modelId: string): string {
-  const normalizedId = modelId.replace(/^(ollama|ollama-cloud|openrouter):/, '');
+  const normalizedId = modelId.replace(/^(ollama|ollama-cloud|openrouter|minimax):/, '');
 
   for (const provider of PROVIDERS) {
     const model = provider.models.find((entry) => entry.id === normalizedId || entry.id === modelId);


### PR DESCRIPTION
Reason: Add MiniMax provider routing with the current model catalog and regional endpoints.

Changes:
- Registers MiniMax in the canonical provider registry with current model metadata, pricing, modality, thinking, and regional endpoint details.
- Adds MiniMax models to the selector through registry metadata.
- Wires MiniMax chat routing through the OpenAI-compatible endpoint with a configurable base URL.

Checks:
- bun test src/providers.test.ts src/utils/model.test.ts src/model/llm.test.ts
- npm run typecheck
- bun test
